### PR TITLE
Feature: Tagged template literal support

### DIFF
--- a/src/base/generator_utils.re
+++ b/src/base/generator_utils.re
@@ -21,6 +21,7 @@ type output_config = {
   delimiter: option(string),
   schema: Schema.schema,
   full_document: Graphql_ast.document,
+  template_literal: option(string),
 };
 
 let filter_map = (f, l) => {

--- a/src/base/graphql_printer.re
+++ b/src/base/graphql_printer.re
@@ -78,7 +78,7 @@ let is_internal_directive = d =>
   switch (d.item.d_name.item) {
   | "bsVariant"
   | "bsRecord"
-  | "bsDecoder" 
+  | "bsDecoder"
   | "bsField" => true
   | _ => false
   };

--- a/src/bucklescript/graphql_ppx.re
+++ b/src/bucklescript/graphql_ppx.re
@@ -161,7 +161,7 @@ let extract_template_literal_from_config = config_fields => {
           config_field =>
             switch (config_field) {
             | (
-                {txt: Longident.Lident("templateLiteral"), _},
+                {txt: Longident.Lident("templateTag"), _},
                 {pexp_desc: Pexp_ident({txt: _}), _},
               ) =>
               true

--- a/src/bucklescript/graphql_ppx.re
+++ b/src/bucklescript/graphql_ppx.re
@@ -162,10 +162,7 @@ let extract_template_literal_from_config = config_fields => {
             switch (config_field) {
             | (
                 {txt: Longident.Lident("templateLiteral"), _},
-                {
-                  pexp_desc: Pexp_ident({txt: Ldot(Longident.Lident(_), _)}),
-                  _,
-                },
+                {pexp_desc: Pexp_ident({txt: _}), _},
               ) =>
               true
             | _ => false
@@ -178,6 +175,12 @@ let extract_template_literal_from_config = config_fields => {
     };
 
   switch (maybe_template_literal_field) {
+  // in case it's a single identifier: "graphql"
+  | Some((_, {pexp_desc: Pexp_ident({txt: Longident.Lident(f)})})) =>
+    Some(f)
+  // in case it's a dot identifier: "Gatsby.graphql"
+  // note we only pattern match on a single dot, so FirstModule.Gatsby.graphql
+  // wouldn't work
   | Some((
       _,
       {pexp_desc: Pexp_ident({txt: Ldot(Longident.Lident(m), fn)})},

--- a/src/bucklescript/graphql_ppx.re
+++ b/src/bucklescript/graphql_ppx.re
@@ -175,17 +175,19 @@ let extract_template_literal_from_config = config_fields => {
     };
 
   switch (maybe_template_literal_field) {
-  // in case it's a single identifier: "graphql"
-  | Some((_, {pexp_desc: Pexp_ident({txt: Longident.Lident(f)})})) =>
-    Some(f)
-  // in case it's a dot identifier: "Gatsby.graphql"
-  // note we only pattern match on a single dot, so FirstModule.Gatsby.graphql
-  // wouldn't work
-  | Some((
-      _,
-      {pexp_desc: Pexp_ident({txt: Ldot(Longident.Lident(m), fn)})},
-    )) =>
-    Some(m ++ "." ++ fn)
+  | Some((_, {pexp_desc: Pexp_ident({txt: lident})})) =>
+    Some(
+      Longident.flatten(lident)
+      |> List.fold_left(
+           (acc, elem) =>
+             if (acc == "") {
+               elem;
+             } else {
+               acc ++ "." ++ elem;
+             },
+           "",
+         ),
+    )
   | _ => None
   };
 };

--- a/src/bucklescript/output_bucklescript_module.re
+++ b/src/bucklescript/output_bucklescript_module.re
@@ -43,12 +43,26 @@ let ret_type_magic = [
   [%stri type t = MT_Ret.t],
 ];
 
+// port of split_on_char from the stdlib because it was only introduced
+// in ocaml 4.04
+let split_on_char = (sep, s) => {
+  let r = ref([]);
+  let j = ref(String.length(s));
+  for (i in String.length(s) - 1 downto 0) {
+    if (String.unsafe_get(s, i) == sep) {
+      r := [String.sub(s, i + 1, j^ - i - 1), ...r^];
+      j := i;
+    };
+  };
+  [String.sub(s, 0, j^), ...r^];
+};
+
 let pretty_print = (query: string): string => {
   let indent = ref(1);
 
   let str =
     query
-    |> String.split_on_char('\n')
+    |> split_on_char('\n')
     |> List.map(l => String.trim(l))
     |> List.filter(l => l != "")
     |> List.map(line => {

--- a/src/bucklescript/output_bucklescript_module.re
+++ b/src/bucklescript/output_bucklescript_module.re
@@ -224,12 +224,16 @@ let make_printed_query = (config, document) => {
           switch (config.template_literal) {
           | None => emit_printed_query(source)
           | Some(template_literal) =>
+            // if the template literal is: "graphql"
+            // a string is created like this: graphql`[query]`
             let tmp =
               emit_printed_query(
                 ~strProcess=str => template_literal ++ "`\n" ++ str ++ "`",
                 source,
               );
 
+            // the only way to emit a template literal for now, using thebs.raw
+            // extension
             Exp.extension((
               {txt: "bs.raw", loc: Location.none},
               PStr([

--- a/src/native/graphql_ppx.re
+++ b/src/native/graphql_ppx.re
@@ -110,6 +110,7 @@ let rewrite_query = (~schema=?, ~loc, ~delim, ~query, ()) => {
         full_document: document,
         /*  the only call site of schema, make it lazy! */
         schema: Lazy.force(Read_schema.get_schema(schema)),
+        template_literal: None,
       };
       switch (Validations.run_validators(config, document)) {
       | Some(errs) =>
@@ -139,7 +140,7 @@ let extract_schema_from_config = config_fields => {
   open Parsetree;
 
   let maybe_schema_field =
-    try (
+    try(
       Some(
         List.find(
           config_field =>


### PR DESCRIPTION
Many JS GraphQL implementation require you to wrap GraphQL queries around a tagged template literal. Mostly so they can do some compiler magic. Such as Apollo can extract al queries in an application into a manifest. That manifest can then be used for several things including that the client doesn't send a whole query, but just an identifier of the query.

Another example is Gatsby. You need to wrap queries so the compiler can recognize them and statically compile the javascript pages with the GraphQL results pre-rendered.

So to facilitate using these libraries in ReasonML we need to emit code that these tools understand.

Unfortunately there is no official template literal escape hatch in Bucklescript. I already created an issue for this as I think this will help a lot for interop. However we can emit template literals with the current versions of Bucklescript, with the bs.raw extension.

There are some downsides to this. Because the contents of bs.raw are a black box, you need to make sure that the identifier you use is imported if they need to be imported (and make sure the identifier is not renamed when there are name collisions). Some tools however it's fine to use a global (unimported) identifier as it's compiled away (Gatsby).

This PR will add template literal support.

For this query:

```reason
module SEO = [%graphql
  {|
    query SEO {
      site {
        siteMetadata {
          defaultTitle: title
          titleTemplate
          siteUrl: url
        }
      }
    }
  |};
  {templateLiteral: graphql}
];
```


Instead of 
```js
var ppx_printed_query = "query SEO  {    site  {      siteMetadata  {        defaultTitle: title        titleTemplate        siteUrl: url      }    }  }`);
```

It will emit:
```js
var ppx_printed_query = (graphql`
  query SEO  {
    site  {
      siteMetadata  {
        defaultTitle: title
        titleTemplate
        siteUrl: url
      }
    }
  }
`);
```

We can make this functionality even better at the moment that Bucklescript adds some kind of support for tagged template literals. Then we can upgrade this functionality without any breaking changes. But this functionality itself will allow me to add ReasonML bindings<sup>[1](#footnote1)</sup> to Gatsby, so this is already worth it I believe.

<a name="footnote1">(1)</a>: I also needed to add a PR to the Gatsby internals to deal with Bucklescript's `import * as Gatsby from 'gatsby'` syntax which was not supported (https://github.com/gatsbyjs/gatsby/pull/20330).