### PR TITLE
adds decoder support to fragment definition

### DIFF
--- a/src/base/result_decoder.re
+++ b/src/base/result_decoder.re
@@ -575,6 +575,8 @@ let rec unify_document_schema = (config, document) => {
       ...rest,
     ] => [
       {
+        open Result;
+
         let with_decoder =
           switch (fg_directives |> find_directive("bsDecoder")) {
           | None => Ok(None)

--- a/src/base/result_decoder.re
+++ b/src/base/result_decoder.re
@@ -613,7 +613,6 @@ let rec unify_document_schema = (config, document) => {
           };
 
         let is_record = has_directive("bsRecord", fg_directives);
-
         switch (Schema.lookup_type(config.schema, fg_type_condition.item)) {
         | None =>
           Mod_fragment(

--- a/tests_bucklescript/__tests__/fragmentDefinition.re
+++ b/tests_bucklescript/__tests__/fragmentDefinition.re
@@ -1,6 +1,26 @@
+type record = {
+  nullableOfNullable: option(array(option(string))),
+  nullableOfNonNullable: option(array(string)),
+};
+
+let concat = ({nullableOfNullable, nullableOfNonNullable}) => {
+  let x =
+    nullableOfNullable
+    ->Belt.Option.getWithDefault([||])
+    ->Belt.Array.keepMap(x => x);
+  let y = nullableOfNonNullable->Belt.Option.getWithDefault([||]);
+
+  Belt.Array.concat(x, y);
+};
+
 module Fragments = [%graphql
   {|
   fragment listFragment on Lists {
+    nullableOfNullable
+    nullableOfNonNullable
+  }
+
+  fragment concatFragment on Lists @bsRecord @bsDecoder(fn: "concat") {
     nullableOfNullable
     nullableOfNonNullable
   }
@@ -18,6 +38,10 @@ module MyQuery = [%graphql
       ...Fragments.ListFragment @bsField(name: "frag1")
       ...Fragments.ListFragment @bsField(name: "frag2")
     }
+
+    l3: lists {
+      ...Fragments.ConcatFragment
+    }
   }
 |}
 ];
@@ -26,30 +50,31 @@ open Jest;
 open Expect;
 
 describe("Fragment definition", () => {
+  let expectedObject = {
+    "nullableOfNullable": Some([|Some("a"), None, Some("b")|]),
+    "nullableOfNonNullable": None,
+  };
+
   test("Decodes the fragment", () =>
     {|
       {
         "l1": {"nullableOfNullable": ["a", null, "b"]},
-        "l2": {"nullableOfNullable": ["a", null, "b"]}
+        "l2": {"nullableOfNullable": ["a", null, "b"]},
+        "l3": {
+          "nullableOfNullable": ["a", null, "b", null, "c"],
+          "nullableOfNonNullable": ["d", "e"]
+          }
       }|}
     |> Js.Json.parseExn
     |> MyQuery.parse
     |> expect
     |> toEqual({
-         "l1": {
-           "nullableOfNullable": Some([|Some("a"), None, Some("b")|]),
-           "nullableOfNonNullable": None,
-         },
+         "l1": expectedObject,
          "l2": {
-           "frag1": {
-             "nullableOfNullable": Some([|Some("a"), None, Some("b")|]),
-             "nullableOfNonNullable": None,
-           },
-           "frag2": {
-             "nullableOfNullable": Some([|Some("a"), None, Some("b")|]),
-             "nullableOfNonNullable": None,
-           },
+           "frag1": expectedObject,
+           "frag2": expectedObject,
          },
+         "l3": [|"a", "b", "c", "d", "e"|],
        })
   );
 

--- a/tests_bucklescript/__tests__/fragmentDefinition.rei
+++ b/tests_bucklescript/__tests__/fragmentDefinition.rei
@@ -1,3 +1,8 @@
+type record = {
+  nullableOfNullable: option(array(option(string))),
+  nullableOfNonNullable: option(array(string)),
+};
+
 module Fragments: {
   module ListFragment: {
     type t = {
@@ -33,6 +38,7 @@ module MyQuery: {
         "nullableOfNonNullable": option(array(string)),
       },
     },
+    "l3": array(string),
   };
 
   let make:


### PR DESCRIPTION
This adds support for `@bsDecoder` on fragments + tests. Previously you could add `@bsDecoder(fn: "some_decoder")`, but it would be removed from the printed query and have no effect.

@baransu We talked about this over in #20.
> As far as I understand your problem is lack of @bsDecoder on fragments for example, as it would simplify your workflow when handling e.g Price fragment as in your example?

This PR fixes that.

AFAICT there shouldn't be a problem with adding decoder support to queries as well, but I'm new here so might not know what I'm talking about.