### PR TITLE
Add OPAM file

### DIFF
--- a/graphql_ppx.opam
+++ b/graphql_ppx.opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "Tomasz Cichocinski <tomaszcichocinski@gmail.com>"
+authors: "Tomasz Cichocinski <tomaszcichocinski@gmail.com>"
+homepage: "https://github.com/reasonml-community/graphql_ppx"
+bug-reports: "https://github.com/reasonml-community/graphql_ppx/issues"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "alcotest" {with-test}
+  "cppo"
+  "dune"
+  "ocaml" {>= "4.06.0"}
+  "ocaml-migrate-parsetree" {>= "1.4.0"}
+  "ppx_tools_versioned" {>= "5.2.3"}
+  "reason"
+  "result"
+  "yojson"
+]
+
+synopsis: "GraphQL PPX rewriter for Bucklescript/ReasonML"
+description: ""

--- a/graphql_ppx.opam
+++ b/graphql_ppx.opam
@@ -13,7 +13,7 @@ depends: [
   "cppo"
   "dune"
   "ocaml" {>= "4.06.0"}
-  "ocaml-migrate-parsetree" {>= "1.4.0"}
+  "ocaml-migrate-parsetree" {>= "1.6.0"}
   "ppx_tools_versioned" {>= "5.2.3"}
   "reason"
   "result"


### PR DESCRIPTION
This PR adds a `graphql_ppx.opam` file, such that this package can be released to OPAM. I've copied the metadata from `package.json` and the dependency constraints from `406.json`.

With the proposed OPAM file in place, I can locally run `opam pin add graphql_ppx /path/to/graphql_ppx` with success.