### PR TITLE
fix(native): remove refmterr from build-command

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -21,7 +21,8 @@
     "refmterr": "*"
   },
   "esy": {
-    "build": [["refmterr", "dune", "build", "-p", "#{self.name}"]],
+    "build": [["dune", "build", "-p", "#{self.name}"]],
+    "buildDev": [["refmterr", "dune", "build", "-p", "#{self.name}"]],
     "buildsInSource": "_build"
   }
 }


### PR DESCRIPTION
Adds a `buildDev` command instead which has `refmterr` since `refmterr` is only available as a devDependency!