### PR TITLE
promote refmterro from build dep to dep

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -12,16 +12,17 @@
     "@opam/ocaml-migrate-parsetree": ">=1.6.0",
     "@opam/ppx_tools_versioned": "5.2.3",
     "@opam/reason": "3.5.2",
-    "@opam/menhir": "*",
-    "refmterr": "*"
+    "@opam/menhir": "*"
   },
   "devDependencies": {
     "@opam/ocamlformat": "*",
     "@opam/alcotest": "*",
-    "ocaml": "~4.9.0"
+    "ocaml": "~4.9.0",
+    "refmterr": "*"
   },
   "esy": {
-    "build": [["refmterr", "dune", "build", "-p", "#{self.name}"]],
+    "build": [["dune", "build", "-p", "#{self.name}"]],
+    "buildDev": [["refmterr", "dune", "build", "-p", "#{self.name}"]],
     "buildsInSource": "_build"
   }
 }

--- a/esy.json
+++ b/esy.json
@@ -12,13 +12,13 @@
     "@opam/ocaml-migrate-parsetree": ">=1.6.0",
     "@opam/ppx_tools_versioned": "5.2.3",
     "@opam/reason": "3.5.2",
-    "@opam/menhir": "*"
+    "@opam/menhir": "*",
+    "refmterr": "*"
   },
   "devDependencies": {
     "@opam/ocamlformat": "*",
     "@opam/alcotest": "*",
-    "ocaml": "~4.9.0",
-    "refmterr": "*"
+    "ocaml": "~4.9.0"
   },
   "esy": {
     "build": [["refmterr", "dune", "build", "-p", "#{self.name}"]],

--- a/esy.json
+++ b/esy.json
@@ -22,7 +22,18 @@
   },
   "esy": {
     "build": [["dune", "build", "-p", "#{self.name}"]],
-    "buildDev": [["refmterr", "dune", "build", "-p", "#{self.name}"]],
+    "buildDev": [
+      [
+        "refmterr",
+        "dune",
+        "build",
+        "--promote-install-files",
+        "--root",
+        ".",
+        "--only-package",
+        "#{self.name}"
+      ]
+    ],
     "buildsInSource": "_build"
   }
 }

--- a/src/bucklescript_bin/Bin.re
+++ b/src/bucklescript_bin/Bin.re
@@ -1,5 +1,3 @@
-open Migrate_parsetree;
-
 let argv =
   switch (Sys.argv |> Array.to_list) {
   | [program, ...rest] =>


### PR DESCRIPTION
If refmterr is a build dependency then its binary is not available to
the build shell of the package depending on graphql_ppx. But since
refmterr is used in the build command of graphql_ppx it needs to be
available in the build shell.

Otherwise this happens:

```sh
info esy 0.6.2 (using package.json)
info checking https://github.com/ocaml/opam-repository for updates...
info checking https://github.com/esy-ocaml/esy-opam-override for updates...
info resolving esy packages: done                         
info solving esy constraints: done         
info resolving npm packages: done
info fetching: done                                                                                              
info installing: done                                                                                                       
info building graphql_ppx@github:reasonml-community/graphql_ppx:esy.json#738a02ed92323f79bc0dd6367d5cb1b95f210517@7514068f
error: build failed with exit code: 1
  build log:
    # esy-build-package: building: graphql_ppx@github:reasonml-community/graphql_ppx:esy.json#738a02ed92323f79bc0dd6367d5cb1b95f210517
    # esy-build-package: pwd: /home/despairblue/.esy/3/b/graphql__ppx-37e43804
    # esy-build-package: running: 'refmterr' 'dune' 'build' '-p' 'graphql_ppx'
    esy-build-package: unable to resolve command: refmterr
    
  building graphql_ppx@github:reasonml-community/graphql_ppx:esy.json#738a02ed92323f79bc0dd6367d5cb1b95f210517
esy: exiting due to errors above
```

Which can be fixed via overrides:

```json
  "resolutions": {
    "graphql_ppx": {
      "source": "reasonml-community/graphql_ppx:esy.json#738a02ed92323f79bc0dd6367d5cb1b95f210517",
      "override": {
        "dependencies": {
          "refmterr": "*"
        }
      }
    }
  }
```