### PR TITLE
Fix bucklescript variants

### DIFF
--- a/src/bucklescript/output_bucklescript_parser.re
+++ b/src/bucklescript/output_bucklescript_parser.re
@@ -427,12 +427,7 @@ and generate_poly_variant_selection_set =
             Exp.variant(
               field_name,
               Some(
-                generate_parser(
-                  config,
-                  [field_name, ...path],
-                  definition,
-                  inner,
-                ),
+                generate_parser(config, [field, ...path], definition, inner),
               ),
             )
           );

--- a/src/bucklescript/output_bucklescript_types.re
+++ b/src/bucklescript/output_bucklescript_types.re
@@ -246,7 +246,7 @@ let generate_variant_selection = (config, fields, path, loc, raw) =>
         Ast_helper.(
           Typ.variant(
             fields
-            |> List.map(((name, field)) =>
+            |> List.map(((name, res)) =>
                  {
                    prf_desc:
                      Rtag(
@@ -255,46 +255,7 @@ let generate_variant_selection = (config, fields, path, loc, raw) =>
                          loc: conv_loc(loc),
                        },
                        false,
-                       [
-                         {
-                           ptyp_desc:
-                             switch (field) {
-                             | Res_array(_, _) =>
-                               Ptyp_constr(
-                                 Location.mknoloc(
-                                   Longident.Lident(
-                                     "array("
-                                     ++ generate_type_name(
-                                          path |> List.append([name]),
-                                        )
-                                     ++ ")",
-                                   ),
-                                 ),
-                                 [],
-                               )
-                             | Res_object(_, _, _, _)
-                             | Res_record(_, _, _, _)
-                             | Res_poly_variant_selection_set(_, _, _)
-                             | Res_poly_variant_union(_, _, _, _)
-                             | Res_poly_variant_interface(_, _, _, _)
-                             | Res_solo_fragment_spread(_, _, _) =>
-                               Ptyp_constr(
-                                 Location.mknoloc(
-                                   Longident.Lident(
-                                     generate_type_name(
-                                       path |> List.append([name]),
-                                     ),
-                                   ),
-                                 ),
-                                 [],
-                               )
-                             | _ => Ptyp_any
-                             },
-                           ptyp_attributes: [],
-                           ptyp_loc_stack: [],
-                           ptyp_loc: Location.none,
-                         },
-                       ],
+                       [generate_type(config, [name, ...path], raw, res)],
                      ),
                    prf_loc: Location.none,
                    prf_attributes: [],

--- a/src/bucklescript/output_bucklescript_types.re
+++ b/src/bucklescript/output_bucklescript_types.re
@@ -246,7 +246,7 @@ let generate_variant_selection = (config, fields, path, loc, raw) =>
         Ast_helper.(
           Typ.variant(
             fields
-            |> List.map(((name, _)) =>
+            |> List.map(((name, field)) =>
                  {
                    prf_desc:
                      Rtag(
@@ -257,7 +257,39 @@ let generate_variant_selection = (config, fields, path, loc, raw) =>
                        false,
                        [
                          {
-                           ptyp_desc: Ptyp_any,
+                           ptyp_desc:
+                             switch (field) {
+                             | Res_array(_, _) =>
+                               Ptyp_constr(
+                                 Location.mknoloc(
+                                   Longident.Lident(
+                                     "array("
+                                     ++ generate_type_name(
+                                          path |> List.append([name]),
+                                        )
+                                     ++ ")",
+                                   ),
+                                 ),
+                                 [],
+                               )
+                             | Res_object(_, _, _, _)
+                             | Res_record(_, _, _, _)
+                             | Res_poly_variant_selection_set(_, _, _)
+                             | Res_poly_variant_union(_, _, _, _)
+                             | Res_poly_variant_interface(_, _, _, _)
+                             | Res_solo_fragment_spread(_, _, _) =>
+                               Ptyp_constr(
+                                 Location.mknoloc(
+                                   Longident.Lident(
+                                     generate_type_name(
+                                       path |> List.append([name]),
+                                     ),
+                                   ),
+                                 ),
+                                 [],
+                               )
+                             | _ => Ptyp_any
+                             },
                            ptyp_attributes: [],
                            ptyp_loc_stack: [],
                            ptyp_loc: Location.none,

--- a/tests_bucklescript/__tests__/__snapshots__/snapshots.bs.js.snap
+++ b/tests_bucklescript/__tests__/__snapshots__/snapshots.bs.js.snap
@@ -4606,6 +4606,139 @@ module MyQuery = {
 "
 `;
 
+exports[`Legacy variant.re 1`] = `
+"[@ocaml.ppx.context
+  {
+    tool_name: \\"migrate_driver\\",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module MyQuery = {
+  module Raw = {
+    type t = {. \\"mutationWithError\\": t_mutationWithError}
+    and t_mutationWithError
+    and t_mutationWithError_errors = {
+      .
+      \\"field\\": t_mutationWithError_errors_field,
+      \\"message\\": string,
+    }
+    and t_mutationWithError_errors_field = string
+    and t_mutationWithError_value = {. \\"stringField\\": string};
+  };
+  let query = \\"mutation   {\\\\nmutationWithError  {\\\\nvalue  {\\\\nstringField  \\\\n}\\\\n\\\\nerrors  {\\\\nfield  \\\\nmessage  \\\\n}\\\\n\\\\n}\\\\n\\\\n}\\\\n\\";
+  type t = {. \\"mutationWithError\\": t_mutationWithError}
+  and t_mutationWithError = [
+    | \`Value(t_mutationWithError_value)
+    | \`Errors(array(t_mutationWithError_errors))
+  ]
+  and t_mutationWithError_errors = {
+    .
+    \\"field\\": t_mutationWithError_errors_field,
+    \\"message\\": string,
+  }
+  and t_mutationWithError_errors_field = [
+    | \`FutureAddedValue(string)
+    | \`FIRST
+    | \`SECOND
+    | \`THIRD
+  ]
+  and t_mutationWithError_value = {. \\"stringField\\": string};
+  let parse: Raw.t => t =
+    value => {
+
+      \\"mutationWithError\\": {
+        let value = value##mutationWithError;
+
+        switch (Js.Json.decodeObject(Obj.magic(value): Js.Json.t)) {
+
+        | None =>
+          Js.Exn.raiseError(
+            \\"graphql_ppx: \\"
+            ++ \\"Expected type \\"
+            ++ \\"MutationWithErrorResult\\"
+            ++ \\" to be an object\\",
+          )
+
+        | Some(value) =>
+          let temp = Js.Dict.unsafeGet(Obj.magic(value), \\"value\\");
+          switch (Js.Json.decodeNull(temp)) {
+          | None =>
+            let value = temp;
+            \`Value({
+
+              \\"stringField\\": {
+                let value = value##stringField;
+
+                value;
+              },
+            });
+          | Some(_) =>
+            let temp = Js.Dict.unsafeGet(Obj.magic(value), \\"errors\\");
+            switch (Js.Json.decodeNull(temp)) {
+            | None =>
+              let value = temp;
+              \`Errors(
+                value
+                |> Js.Array.map(value =>
+                     {
+
+                       \\"field\\": {
+                         let value = value##field;
+                         switch (Obj.magic(value: string)) {
+                         | \\"FIRST\\" => \`FIRST
+                         | \\"SECOND\\" => \`SECOND
+                         | \\"THIRD\\" => \`THIRD
+                         | other => \`FutureAddedValue(other)
+                         };
+                       },
+
+                       \\"message\\": {
+                         let value = value##message;
+
+                         value;
+                       },
+                     }
+                   ),
+              );
+            | Some(_) =>
+              Js.Exn.raiseError(
+                \\"graphql_ppx: \\"
+                ++ \\"All fields on variant selection set on type \\"
+                ++ \\"MutationWithErrorResult\\"
+                ++ \\" were null\\",
+              )
+            };
+          };
+        };
+      },
+    };
+  let makeVar = (~f, ()) => f(Js.Json.null);
+  let make =
+    makeVar(~f=variables =>
+      {\\"query\\": query, \\"variables\\": variables, \\"parse\\": parse}
+    );
+  let makeWithVariables = variables => {
+    \\"query\\": query,
+    \\"variables\\": serializeVariables(variables),
+    \\"parse\\": parse,
+  };
+  let definition = (parse, query, makeVar);
+};
+"
+`;
+
 exports[`Objects argNamedQuery.re 1`] = `
 "[@ocaml.ppx.context
   {
@@ -8888,6 +9021,130 @@ module MyQuery = {
               }
             }
           }
+        };
+      },
+    };
+  let makeVar = (~f, ()) => f(Js.Json.null);
+  let definition = (parse, query, makeVar);
+};
+"
+`;
+
+exports[`Objects variant.re 1`] = `
+"[@ocaml.ppx.context
+  {
+    tool_name: \\"migrate_driver\\",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module MyQuery = {
+  module Raw = {
+    type t = {. \\"mutationWithError\\": t_mutationWithError}
+    and t_mutationWithError
+    and t_mutationWithError_errors = {
+      .
+      \\"field\\": t_mutationWithError_errors_field,
+      \\"message\\": string,
+    }
+    and t_mutationWithError_errors_field = string
+    and t_mutationWithError_value = {. \\"stringField\\": string};
+  };
+  let query = \\"mutation   {\\\\nmutationWithError  {\\\\nvalue  {\\\\nstringField  \\\\n}\\\\n\\\\nerrors  {\\\\nfield  \\\\nmessage  \\\\n}\\\\n\\\\n}\\\\n\\\\n}\\\\n\\";
+  type t = {. \\"mutationWithError\\": t_mutationWithError}
+  and t_mutationWithError = [
+    | \`Value(t_mutationWithError_value)
+    | \`Errors(array(t_mutationWithError_errors))
+  ]
+  and t_mutationWithError_errors = {
+    .
+    \\"field\\": t_mutationWithError_errors_field,
+    \\"message\\": string,
+  }
+  and t_mutationWithError_errors_field = [
+    | \`FutureAddedValue(string)
+    | \`FIRST
+    | \`SECOND
+    | \`THIRD
+  ]
+  and t_mutationWithError_value = {. \\"stringField\\": string};
+  let parse: Raw.t => t =
+    value => {
+
+      \\"mutationWithError\\": {
+        let value = value##mutationWithError;
+
+        switch (Js.Json.decodeObject(Obj.magic(value): Js.Json.t)) {
+
+        | None =>
+          Js.Exn.raiseError(
+            \\"graphql_ppx: \\"
+            ++ \\"Expected type \\"
+            ++ \\"MutationWithErrorResult\\"
+            ++ \\" to be an object\\",
+          )
+
+        | Some(value) =>
+          let temp = Js.Dict.unsafeGet(Obj.magic(value), \\"value\\");
+          switch (Js.Json.decodeNull(temp)) {
+          | None =>
+            let value = temp;
+            \`Value({
+
+              \\"stringField\\": {
+                let value = value##stringField;
+
+                value;
+              },
+            });
+          | Some(_) =>
+            let temp = Js.Dict.unsafeGet(Obj.magic(value), \\"errors\\");
+            switch (Js.Json.decodeNull(temp)) {
+            | None =>
+              let value = temp;
+              \`Errors(
+                value
+                |> Js.Array.map(value =>
+                     {
+
+                       \\"field\\": {
+                         let value = value##field;
+                         switch (Obj.magic(value: string)) {
+                         | \\"FIRST\\" => \`FIRST
+                         | \\"SECOND\\" => \`SECOND
+                         | \\"THIRD\\" => \`THIRD
+                         | other => \`FutureAddedValue(other)
+                         };
+                       },
+
+                       \\"message\\": {
+                         let value = value##message;
+
+                         value;
+                       },
+                     }
+                   ),
+              );
+            | Some(_) =>
+              Js.Exn.raiseError(
+                \\"graphql_ppx: \\"
+                ++ \\"All fields on variant selection set on type \\"
+                ++ \\"MutationWithErrorResult\\"
+                ++ \\" were null\\",
+              )
+            };
+          };
         };
       },
     };
@@ -13276,6 +13533,137 @@ module MyQuery = {
                 }
               }
             }
+          };
+        },
+      }: t
+    );
+  let makeVar = (~f, ()) => f(Js.Json.null);
+  let definition = (parse, query, makeVar);
+};
+"
+`;
+
+exports[`Records variant.re 1`] = `
+"[@ocaml.ppx.context
+  {
+    tool_name: \\"migrate_driver\\",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module MyQuery = {
+  module Raw = {
+    type t = {mutationWithError: t_mutationWithError}
+    and t_mutationWithError
+    and t_mutationWithError_errors = {
+      field: t_mutationWithError_errors_field,
+      message: string,
+    }
+    and t_mutationWithError_errors_field = string
+    and t_mutationWithError_value = {stringField: string};
+  };
+  let query = \\"mutation   {\\\\nmutationWithError  {\\\\nvalue  {\\\\nstringField  \\\\n}\\\\n\\\\nerrors  {\\\\nfield  \\\\nmessage  \\\\n}\\\\n\\\\n}\\\\n\\\\n}\\\\n\\";
+  type t = {mutationWithError: t_mutationWithError}
+  and t_mutationWithError = [
+    | \`Value(t_mutationWithError_value)
+    | \`Errors(array(t_mutationWithError_errors))
+  ]
+  and t_mutationWithError_errors = {
+    field: t_mutationWithError_errors_field,
+    message: string,
+  }
+  and t_mutationWithError_errors_field = [
+    | \`FutureAddedValue(string)
+    | \`FIRST
+    | \`SECOND
+    | \`THIRD
+  ]
+  and t_mutationWithError_value = {stringField: string};
+  let parse: Raw.t => t =
+    (value) => (
+      {
+
+        mutationWithError: {
+          let value = (value: Raw.t).mutationWithError;
+
+          switch (Js.Json.decodeObject(Obj.magic(value): Js.Json.t)) {
+
+          | None =>
+            Js.Exn.raiseError(
+              \\"graphql_ppx: \\"
+              ++ \\"Expected type \\"
+              ++ \\"MutationWithErrorResult\\"
+              ++ \\" to be an object\\",
+            )
+
+          | Some(value) =>
+            let temp = Js.Dict.unsafeGet(Obj.magic(value), \\"value\\");
+            switch (Js.Json.decodeNull(temp)) {
+            | None =>
+              let value = temp;
+              \`Value(
+                {
+
+                  stringField: {
+                    let value =
+                      (value: Raw.t_mutationWithError_value).stringField;
+
+                    value;
+                  },
+                }: t_mutationWithError_value,
+              );
+            | Some(_) =>
+              let temp = Js.Dict.unsafeGet(Obj.magic(value), \\"errors\\");
+              switch (Js.Json.decodeNull(temp)) {
+              | None =>
+                let value = temp;
+                \`Errors(
+                  value
+                  |> Js.Array.map((value) =>
+                       (
+                         {
+
+                           field: {
+                             let value =
+                               (value: Raw.t_mutationWithError_errors).field;
+                             switch (Obj.magic(value: string)) {
+                             | \\"FIRST\\" => \`FIRST
+                             | \\"SECOND\\" => \`SECOND
+                             | \\"THIRD\\" => \`THIRD
+                             | other => \`FutureAddedValue(other)
+                             };
+                           },
+
+                           message: {
+                             let value =
+                               (value: Raw.t_mutationWithError_errors).message;
+
+                             value;
+                           },
+                         }: t_mutationWithError_errors
+                       )
+                     ),
+                );
+              | Some(_) =>
+                Js.Exn.raiseError(
+                  \\"graphql_ppx: \\"
+                  ++ \\"All fields on variant selection set on type \\"
+                  ++ \\"MutationWithErrorResult\\"
+                  ++ \\" were null\\",
+                )
+              };
+            };
           };
         },
       }: t

--- a/tests_bucklescript/operations/variant.re
+++ b/tests_bucklescript/operations/variant.re
@@ -1,0 +1,16 @@
+module MyQuery = [%graphql
+  {|
+  mutation {
+    mutationWithError @bsVariant {
+      value {
+        stringField
+      }
+
+      errors {
+        field
+        message
+      }
+    }
+  }
+|}
+];

--- a/tests_bucklescript/static_snapshots/legacy/operations/variant.re
+++ b/tests_bucklescript/static_snapshots/legacy/operations/variant.re
@@ -1,0 +1,129 @@
+[@ocaml.ppx.context
+  {
+    tool_name: "migrate_driver",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module MyQuery = {
+  module Raw = {
+    type t = {. "mutationWithError": t_mutationWithError}
+    and t_mutationWithError
+    and t_mutationWithError_errors = {
+      .
+      "field": t_mutationWithError_errors_field,
+      "message": string,
+    }
+    and t_mutationWithError_errors_field = string
+    and t_mutationWithError_value = {. "stringField": string};
+  };
+  let query = "mutation   {\nmutationWithError  {\nvalue  {\nstringField  \n}\n\nerrors  {\nfield  \nmessage  \n}\n\n}\n\n}\n";
+  type t = {. "mutationWithError": t_mutationWithError}
+  and t_mutationWithError = [
+    | `Value(t_mutationWithError_value)
+    | `Errors(array(t_mutationWithError_errors))
+  ]
+  and t_mutationWithError_errors = {
+    .
+    "field": t_mutationWithError_errors_field,
+    "message": string,
+  }
+  and t_mutationWithError_errors_field = [
+    | `FutureAddedValue(string)
+    | `FIRST
+    | `SECOND
+    | `THIRD
+  ]
+  and t_mutationWithError_value = {. "stringField": string};
+  let parse: Raw.t => t =
+    value => {
+
+      "mutationWithError": {
+        let value = value##mutationWithError;
+
+        switch (Js.Json.decodeObject(Obj.magic(value): Js.Json.t)) {
+
+        | None =>
+          Js.Exn.raiseError(
+            "graphql_ppx: "
+            ++ "Expected type "
+            ++ "MutationWithErrorResult"
+            ++ " to be an object",
+          )
+
+        | Some(value) =>
+          let temp = Js.Dict.unsafeGet(Obj.magic(value), "value");
+          switch (Js.Json.decodeNull(temp)) {
+          | None =>
+            let value = temp;
+            `Value({
+
+              "stringField": {
+                let value = value##stringField;
+
+                value;
+              },
+            });
+          | Some(_) =>
+            let temp = Js.Dict.unsafeGet(Obj.magic(value), "errors");
+            switch (Js.Json.decodeNull(temp)) {
+            | None =>
+              let value = temp;
+              `Errors(
+                value
+                |> Js.Array.map(value =>
+                     {
+
+                       "field": {
+                         let value = value##field;
+                         switch (Obj.magic(value: string)) {
+                         | "FIRST" => `FIRST
+                         | "SECOND" => `SECOND
+                         | "THIRD" => `THIRD
+                         | other => `FutureAddedValue(other)
+                         };
+                       },
+
+                       "message": {
+                         let value = value##message;
+
+                         value;
+                       },
+                     }
+                   ),
+              );
+            | Some(_) =>
+              Js.Exn.raiseError(
+                "graphql_ppx: "
+                ++ "All fields on variant selection set on type "
+                ++ "MutationWithErrorResult"
+                ++ " were null",
+              )
+            };
+          };
+        };
+      },
+    };
+  let makeVar = (~f, ()) => f(Js.Json.null);
+  let make =
+    makeVar(~f=variables =>
+      {"query": query, "variables": variables, "parse": parse}
+    );
+  let makeWithVariables = variables => {
+    "query": query,
+    "variables": serializeVariables(variables),
+    "parse": parse,
+  };
+  let definition = (parse, query, makeVar);
+};

--- a/tests_bucklescript/static_snapshots/objects/operations/variant.re
+++ b/tests_bucklescript/static_snapshots/objects/operations/variant.re
@@ -1,0 +1,120 @@
+[@ocaml.ppx.context
+  {
+    tool_name: "migrate_driver",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module MyQuery = {
+  module Raw = {
+    type t = {. "mutationWithError": t_mutationWithError}
+    and t_mutationWithError
+    and t_mutationWithError_errors = {
+      .
+      "field": t_mutationWithError_errors_field,
+      "message": string,
+    }
+    and t_mutationWithError_errors_field = string
+    and t_mutationWithError_value = {. "stringField": string};
+  };
+  let query = "mutation   {\nmutationWithError  {\nvalue  {\nstringField  \n}\n\nerrors  {\nfield  \nmessage  \n}\n\n}\n\n}\n";
+  type t = {. "mutationWithError": t_mutationWithError}
+  and t_mutationWithError = [
+    | `Value(t_mutationWithError_value)
+    | `Errors(array(t_mutationWithError_errors))
+  ]
+  and t_mutationWithError_errors = {
+    .
+    "field": t_mutationWithError_errors_field,
+    "message": string,
+  }
+  and t_mutationWithError_errors_field = [
+    | `FutureAddedValue(string)
+    | `FIRST
+    | `SECOND
+    | `THIRD
+  ]
+  and t_mutationWithError_value = {. "stringField": string};
+  let parse: Raw.t => t =
+    value => {
+
+      "mutationWithError": {
+        let value = value##mutationWithError;
+
+        switch (Js.Json.decodeObject(Obj.magic(value): Js.Json.t)) {
+
+        | None =>
+          Js.Exn.raiseError(
+            "graphql_ppx: "
+            ++ "Expected type "
+            ++ "MutationWithErrorResult"
+            ++ " to be an object",
+          )
+
+        | Some(value) =>
+          let temp = Js.Dict.unsafeGet(Obj.magic(value), "value");
+          switch (Js.Json.decodeNull(temp)) {
+          | None =>
+            let value = temp;
+            `Value({
+
+              "stringField": {
+                let value = value##stringField;
+
+                value;
+              },
+            });
+          | Some(_) =>
+            let temp = Js.Dict.unsafeGet(Obj.magic(value), "errors");
+            switch (Js.Json.decodeNull(temp)) {
+            | None =>
+              let value = temp;
+              `Errors(
+                value
+                |> Js.Array.map(value =>
+                     {
+
+                       "field": {
+                         let value = value##field;
+                         switch (Obj.magic(value: string)) {
+                         | "FIRST" => `FIRST
+                         | "SECOND" => `SECOND
+                         | "THIRD" => `THIRD
+                         | other => `FutureAddedValue(other)
+                         };
+                       },
+
+                       "message": {
+                         let value = value##message;
+
+                         value;
+                       },
+                     }
+                   ),
+              );
+            | Some(_) =>
+              Js.Exn.raiseError(
+                "graphql_ppx: "
+                ++ "All fields on variant selection set on type "
+                ++ "MutationWithErrorResult"
+                ++ " were null",
+              )
+            };
+          };
+        };
+      },
+    };
+  let makeVar = (~f, ()) => f(Js.Json.null);
+  let definition = (parse, query, makeVar);
+};

--- a/tests_bucklescript/static_snapshots/records/operations/variant.re
+++ b/tests_bucklescript/static_snapshots/records/operations/variant.re
@@ -47,10 +47,12 @@ module MyQuery = {
   let parse: Raw.t => t =
     (value) => (
       {
+
         mutationWithError: {
           let value = (value: Raw.t).mutationWithError;
 
           switch (Js.Json.decodeObject(Obj.magic(value): Js.Json.t)) {
+
           | None =>
             Js.Exn.raiseError(
               "graphql_ppx: "
@@ -66,6 +68,7 @@ module MyQuery = {
               let value = temp;
               `Value(
                 {
+
                   stringField: {
                     let value =
                       (value: Raw.t_mutationWithError_value).stringField;
@@ -84,6 +87,7 @@ module MyQuery = {
                   |> Js.Array.map((value) =>
                        (
                          {
+
                            field: {
                              let value =
                                (value: Raw.t_mutationWithError_errors).field;

--- a/tests_bucklescript/static_snapshots/records/operations/variant.re
+++ b/tests_bucklescript/static_snapshots/records/operations/variant.re
@@ -1,0 +1,123 @@
+[@ocaml.ppx.context
+  {
+    tool_name: "migrate_driver",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module MyQuery = {
+  module Raw = {
+    type t = {mutationWithError: t_mutationWithError}
+    and t_mutationWithError
+    and t_mutationWithError_errors = {
+      field: t_mutationWithError_errors_field,
+      message: string,
+    }
+    and t_mutationWithError_errors_field = string
+    and t_mutationWithError_value = {stringField: string};
+  };
+  let query = "mutation   {\nmutationWithError  {\nvalue  {\nstringField  \n}\n\nerrors  {\nfield  \nmessage  \n}\n\n}\n\n}\n";
+  type t = {mutationWithError: t_mutationWithError}
+  and t_mutationWithError = [
+    | `Value(t_mutationWithError_value)
+    | `Errors(array(t_mutationWithError_errors))
+  ]
+  and t_mutationWithError_errors = {
+    field: t_mutationWithError_errors_field,
+    message: string,
+  }
+  and t_mutationWithError_errors_field = [
+    | `FutureAddedValue(string)
+    | `FIRST
+    | `SECOND
+    | `THIRD
+  ]
+  and t_mutationWithError_value = {stringField: string};
+  let parse: Raw.t => t =
+    (value) => (
+      {
+        mutationWithError: {
+          let value = (value: Raw.t).mutationWithError;
+
+          switch (Js.Json.decodeObject(Obj.magic(value): Js.Json.t)) {
+          | None =>
+            Js.Exn.raiseError(
+              "graphql_ppx: "
+              ++ "Expected type "
+              ++ "MutationWithErrorResult"
+              ++ " to be an object",
+            )
+
+          | Some(value) =>
+            let temp = Js.Dict.unsafeGet(Obj.magic(value), "value");
+            switch (Js.Json.decodeNull(temp)) {
+            | None =>
+              let value = temp;
+              `Value(
+                {
+                  stringField: {
+                    let value =
+                      (value: Raw.t_mutationWithError_value).stringField;
+
+                    value;
+                  },
+                }: t_mutationWithError_value,
+              );
+            | Some(_) =>
+              let temp = Js.Dict.unsafeGet(Obj.magic(value), "errors");
+              switch (Js.Json.decodeNull(temp)) {
+              | None =>
+                let value = temp;
+                `Errors(
+                  value
+                  |> Js.Array.map((value) =>
+                       (
+                         {
+                           field: {
+                             let value =
+                               (value: Raw.t_mutationWithError_errors).field;
+                             switch (Obj.magic(value: string)) {
+                             | "FIRST" => `FIRST
+                             | "SECOND" => `SECOND
+                             | "THIRD" => `THIRD
+                             | other => `FutureAddedValue(other)
+                             };
+                           },
+
+                           message: {
+                             let value =
+                               (value: Raw.t_mutationWithError_errors).message;
+
+                             value;
+                           },
+                         }: t_mutationWithError_errors
+                       )
+                     ),
+                );
+              | Some(_) =>
+                Js.Exn.raiseError(
+                  "graphql_ppx: "
+                  ++ "All fields on variant selection set on type "
+                  ++ "MutationWithErrorResult"
+                  ++ " were null",
+                )
+              };
+            };
+          };
+        },
+      }: t
+    );
+  let makeVar = (~f, ()) => f(Js.Json.null);
+  let definition = (parse, query, makeVar);
+};


### PR DESCRIPTION
This PR aims to adjust the bucklescript code generation by the ppx, to be able to parse `@bsVariant` where the variant types are complex. These did not work before and were replaced with an opaque type, resulting in an error.