### PR TITLE
ppxAs Bucklescript parser fix

### DIFF
--- a/src/bucklescript/output_bucklescript_parser.re
+++ b/src/bucklescript/output_bucklescript_parser.re
@@ -323,10 +323,14 @@ and generate_object_decoder =
                                {
                                  txt:
                                    Longident.parse(
-                                     "Raw."
-                                     ++ Extract_type_definitions.generate_type_name(
-                                          path,
-                                        ),
+                                     switch (existing_record) {
+                                     | None =>
+                                       "Raw."
+                                       ++ Extract_type_definitions.generate_type_name(
+                                            path,
+                                          )
+                                     | Some(type_name) => type_name
+                                     },
                                    ),
                                  loc: Location.none,
                                },
@@ -414,7 +418,8 @@ and generate_object_decoder =
       do_obj_constructor_records();
     };
 
-  config.records ? obj_constructor_records() : obj_constructor();
+  config.records || existing_record |> Stdlib.Option.is_some
+    ? obj_constructor_records() : obj_constructor();
 }
 and generate_poly_variant_selection_set =
     (config, loc, name, fields, path, definition) => {

--- a/tests_bucklescript/static_snapshots/legacy/operations/record.re
+++ b/tests_bucklescript/static_snapshots/legacy/operations/record.re
@@ -39,20 +39,22 @@ module MyQuery = {
 
       "variousScalars": {
         let value = value##variousScalars;
-        {
+        (
+          {
 
-          "string": {
-            let value = value##string;
+            string: {
+              let value = (value: scalars).string;
 
-            value;
-          },
+              value;
+            },
 
-          "int": {
-            let value = value##int;
+            int: {
+              let value = (value: scalars).int;
 
-            value;
-          },
-        };
+              value;
+            },
+          }: scalars
+        );
       },
     };
   let makeVar = (~f, ()) => f(Js.Json.null);

--- a/tests_bucklescript/static_snapshots/objects/operations/record.re
+++ b/tests_bucklescript/static_snapshots/objects/operations/record.re
@@ -36,23 +36,23 @@ module MyQuery = {
   type t = {. "variousScalars": scalars};
   let parse: Raw.t => t =
     value => {
-
       "variousScalars": {
         let value = value##variousScalars;
-        {
+        (
+          {
+            string: {
+              let value = (value: scalars).string;
 
-          "string": {
-            let value = value##string;
+              value;
+            },
 
-            value;
-          },
+            int: {
+              let value = (value: scalars).int;
 
-          "int": {
-            let value = value##int;
-
-            value;
-          },
-        };
+              value;
+            },
+          }: scalars
+        );
       },
     };
   let makeVar = (~f, ()) => f(Js.Json.null);
@@ -69,11 +69,9 @@ module OneFieldQuery = {
   and t_variousScalars = {nullableString: option(string)};
   let parse: Raw.t => t =
     value => {
-
       "variousScalars": {
         let value = value##variousScalars;
         {
-
           "nullableString": {
             let value = value##nullableString;
 
@@ -106,7 +104,6 @@ module ExternalFragmentQuery = {
     type t_VariousScalars = t;
 
     let parse = (value: Raw.t) => {
-
       "string": {
         let value = value##string;
 
@@ -134,7 +131,6 @@ module ExternalFragmentQuery = {
     type t = {. "variousScalars": Fragment.t};
     let parse: Raw.t => t =
       value => {
-
         "variousScalars": {
           let value = value##variousScalars;
 
@@ -167,12 +163,10 @@ module InlineFragmentQuery = {
   };
   let parse: Raw.t => t =
     value => {
-
       "dogOrHuman": {
         let value = value##dogOrHuman;
 
         switch (Js.Json.decodeObject(Obj.magic(value): Js.Json.t)) {
-
         | None =>
           Js.Exn.raiseError(
             "graphql_ppx: "
@@ -184,7 +178,6 @@ module InlineFragmentQuery = {
 
         | Some(typename_obj) =>
           switch (Js.Dict.get(typename_obj, "__typename")) {
-
           | None =>
             Js.Exn.raiseError(
               "graphql_ppx: "
@@ -195,7 +188,6 @@ module InlineFragmentQuery = {
 
           | Some(typename) =>
             switch (Js.Json.decodeString(typename)) {
-
             | None =>
               Js.Exn.raiseError(
                 "graphql_ppx: "
@@ -211,7 +203,6 @@ module InlineFragmentQuery = {
                   {
                     let value: Raw.t_dogOrHuman_Dog = Obj.magic(value);
                     {
-
                       "name": {
                         let value = value##name;
 
@@ -254,7 +245,6 @@ module UnionExternalFragmentQuery = {
     type t_Dog = t;
 
     let parse = (value: Raw.t) => {
-
       "name": {
         let value = value##name;
 
@@ -290,12 +280,10 @@ module UnionExternalFragmentQuery = {
     ];
     let parse: Raw.t => t =
       value => {
-
         "dogOrHuman": {
           let value = value##dogOrHuman;
 
           switch (Js.Json.decodeObject(Obj.magic(value): Js.Json.t)) {
-
           | None =>
             Js.Exn.raiseError(
               "graphql_ppx: "
@@ -307,7 +295,6 @@ module UnionExternalFragmentQuery = {
 
           | Some(typename_obj) =>
             switch (Js.Dict.get(typename_obj, "__typename")) {
-
             | None =>
               Js.Exn.raiseError(
                 "graphql_ppx: "
@@ -318,7 +305,6 @@ module UnionExternalFragmentQuery = {
 
             | Some(typename) =>
               switch (Js.Json.decodeString(typename)) {
-
               | None =>
                 Js.Exn.raiseError(
                   "graphql_ppx: "

--- a/tests_bucklescript/static_snapshots/records/operations/record.re
+++ b/tests_bucklescript/static_snapshots/records/operations/record.re
@@ -44,13 +44,13 @@ module MyQuery = {
             {
 
               string: {
-                let value = (value: Raw.t_variousScalars).string;
+                let value = (value: scalars).string;
 
                 value;
               },
 
               int: {
-                let value = (value: Raw.t_variousScalars).int;
+                let value = (value: scalars).int;
 
                 value;
               },


### PR DESCRIPTION
Right now it seems that using the `@ppxAs` directive is broken. The generated type definitions reference the given type directly, whereas the generated parser tries to access the (not in actuality) generated typename.

An example is the already present `record.re` test operation.
```reason
type scalars  = {
  string,
  int,
};
module MyQuery = [%graphql
  {|
  {
    variousScalars @ppxAs(type: "scalars") {
      string
      int
    }
  }
|}
];
```

Generates:
```reason
// ...
module Raw = {
  type t = {variousScalars: scalars};
};
// ...
type t = {variousScalars: scalars};
// ...
let value = (value: Raw.t).variousScalars;
(
  {

    string: {
      let value = (value: Raw.t_variousScalars).string;

      value;
    },
// ...
```

**Raw.t_variousScalars** can not be accessed and throws an error, as that type is never generated as an alias.

I have attempted to introduce a small fix for this in this PR. This solutions works for record generation, but object / legacy do not work with this.

Probably not much more is needed, so I'd be happy about suggestions / locations in the code to check out.