### PR TITLE
Add snapshot that shows failing arguments when using objects

### DIFF
--- a/tests_bucklescript/__tests__/__snapshots__/snapshots.bs.js.snap
+++ b/tests_bucklescript/__tests__/__snapshots__/snapshots.bs.js.snap
@@ -2560,7 +2560,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      required: (a => a)(inp##required),
+      \\"required\\": (a => a)(inp##required),
     };
   let makeVariables = (~required, ()) =>
     serializeVariables(
@@ -7129,7 +7129,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      query: (a => a)(inp##query),
+      \\"query\\": (a => a)(inp##query),
     };
   let make = (~query, ()) => {
     \\"query\\": query,
@@ -7228,16 +7228,16 @@ module MyQuery = {
   let rec serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      arg: (a => serializeInputObjectNonrecursiveInput(a))(inp##arg),
+      \\"arg\\": (a => serializeInputObjectNonrecursiveInput(a))(inp##arg),
     }
 
   and serializeInputObjectNonrecursiveInput:
     t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput =
     inp => {
 
-      nonNullableField: (a => a)(inp##nonNullableField),
+      \\"nonNullableField\\": (a => a)(inp##nonNullableField),
 
-      nullableArray:
+      \\"nullableArray\\":
         (
           a =>
             switch (a) {
@@ -7268,7 +7268,7 @@ module MyQuery = {
           inp##nullableArray,
         ),
 
-      field:
+      \\"field\\":
         (
           a =>
             switch (a) {
@@ -7279,7 +7279,7 @@ module MyQuery = {
           inp##field,
         ),
 
-      enum:
+      \\"enum\\":
         (
           a =>
             switch (a) {
@@ -7302,7 +7302,7 @@ module MyQuery = {
           inp##enum,
         ),
 
-      embeddedInput:
+      \\"embeddedInput\\":
         (
           a =>
             switch (a) {
@@ -7343,7 +7343,7 @@ module MyQuery = {
     t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput =
     inp => {
 
-      field:
+      \\"field\\":
         (
           a =>
             switch (a) {
@@ -7599,7 +7599,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      opt:
+      \\"opt\\":
         (
           a =>
             switch (a) {
@@ -7610,7 +7610,7 @@ module MyQuery = {
           inp##opt,
         ),
 
-      req: (a => a)(inp##req),
+      \\"req\\": (a => a)(inp##req),
     };
   let make = (~opt=?, ~req, ()) => {
     \\"query\\": query,
@@ -7829,7 +7829,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      arg:
+      \\"arg\\":
         (
           a =>
             switch (a) {
@@ -8880,7 +8880,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      nullableOfNullable:
+      \\"nullableOfNullable\\":
         (
           a =>
             switch (a) {
@@ -8911,7 +8911,7 @@ module MyQuery = {
           inp##nullableOfNullable,
         ),
 
-      nullableOfNonNullable:
+      \\"nullableOfNonNullable\\":
         (
           a =>
             switch (a) {
@@ -8923,7 +8923,7 @@ module MyQuery = {
           inp##nullableOfNonNullable,
         ),
 
-      nonNullableOfNullable:
+      \\"nonNullableOfNullable\\":
         (
           a =>
             Array.map(
@@ -8943,7 +8943,7 @@ module MyQuery = {
           inp##nonNullableOfNullable,
         ),
 
-      nonNullableOfNonNullable:
+      \\"nonNullableOfNonNullable\\":
         (a => Array.map(b => (a => a)(b), a))(
           inp##nonNullableOfNonNullable,
         ),
@@ -9066,14 +9066,14 @@ module MyQuery = {
   let rec serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      arg: (a => serializeInputObjectListsInput(a))(inp##arg),
+      \\"arg\\": (a => serializeInputObjectListsInput(a))(inp##arg),
     }
 
   and serializeInputObjectListsInput:
     t_variables_ListsInput => Raw.t_variables_ListsInput =
     inp => {
 
-      nullableOfNullable:
+      \\"nullableOfNullable\\":
         (
           a =>
             switch (a) {
@@ -9104,7 +9104,7 @@ module MyQuery = {
           inp##nullableOfNullable,
         ),
 
-      nullableOfNonNullable:
+      \\"nullableOfNonNullable\\":
         (
           a =>
             switch (a) {
@@ -9116,7 +9116,7 @@ module MyQuery = {
           inp##nullableOfNonNullable,
         ),
 
-      nonNullableOfNullable:
+      \\"nonNullableOfNullable\\":
         (
           a =>
             Array.map(
@@ -9136,7 +9136,7 @@ module MyQuery = {
           inp##nonNullableOfNullable,
         ),
 
-      nonNullableOfNonNullable:
+      \\"nonNullableOfNonNullable\\":
         (a => Array.map(b => (a => a)(b), a))(
           inp##nonNullableOfNonNullable,
         ),
@@ -9418,7 +9418,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      required: (a => a)(inp##required),
+      \\"required\\": (a => a)(inp##required),
     };
   let make = (~required, ()) => {
     \\"query\\": query,
@@ -9497,7 +9497,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      required: (a => a)(inp##required),
+      \\"required\\": (a => a)(inp##required),
     };
   let make = (~required, ()) => {
     \\"query\\": query,
@@ -9908,16 +9908,16 @@ module MyQuery = {
   let rec serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      arg: (a => serializeInputObjectNonrecursiveInput(a))(inp##arg),
+      \\"arg\\": (a => serializeInputObjectNonrecursiveInput(a))(inp##arg),
     }
 
   and serializeInputObjectNonrecursiveInput:
     t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput =
     inp => {
 
-      nonNullableField: (a => a)(inp##nonNullableField),
+      \\"nonNullableField\\": (a => a)(inp##nonNullableField),
 
-      nullableArray:
+      \\"nullableArray\\":
         (
           a =>
             switch (a) {
@@ -9948,7 +9948,7 @@ module MyQuery = {
           inp##nullableArray,
         ),
 
-      field:
+      \\"field\\":
         (
           a =>
             switch (a) {
@@ -9959,7 +9959,7 @@ module MyQuery = {
           inp##field,
         ),
 
-      enum:
+      \\"enum\\":
         (
           a =>
             switch (a) {
@@ -9982,7 +9982,7 @@ module MyQuery = {
           inp##enum,
         ),
 
-      embeddedInput:
+      \\"embeddedInput\\":
         (
           a =>
             switch (a) {
@@ -10023,7 +10023,7 @@ module MyQuery = {
     t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput =
     inp => {
 
-      field:
+      \\"field\\":
         (
           a =>
             switch (a) {
@@ -10302,7 +10302,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      id:
+      \\"id\\":
         (
           a =>
             switch (a) {
@@ -10313,7 +10313,7 @@ module MyQuery = {
           inp##id,
         ),
 
-      name:
+      \\"name\\":
         (
           a =>
             switch (a) {
@@ -10852,14 +10852,14 @@ module MyQuery = {
   let rec serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      arg: (a => serializeInputObjectRecursiveInput(a))(inp##arg),
+      \\"arg\\": (a => serializeInputObjectRecursiveInput(a))(inp##arg),
     }
 
   and serializeInputObjectRecursiveInput:
     t_variables_RecursiveInput => Raw.t_variables_RecursiveInput =
     inp => {
 
-      otherField:
+      \\"otherField\\":
         (
           a =>
             switch (a) {
@@ -10870,7 +10870,7 @@ module MyQuery = {
           inp##otherField,
         ),
 
-      inner:
+      \\"inner\\":
         (
           a =>
             switch (a) {
@@ -10884,7 +10884,7 @@ module MyQuery = {
           inp##inner,
         ),
 
-      enum:
+      \\"enum\\":
         (
           a =>
             switch (a) {
@@ -11238,7 +11238,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      nullableString:
+      \\"nullableString\\":
         (
           a =>
             switch (a) {
@@ -11249,9 +11249,9 @@ module MyQuery = {
           inp##nullableString,
         ),
 
-      string: (a => a)(inp##string),
+      \\"string\\": (a => a)(inp##string),
 
-      nullableInt:
+      \\"nullableInt\\":
         (
           a =>
             switch (a) {
@@ -11262,9 +11262,9 @@ module MyQuery = {
           inp##nullableInt,
         ),
 
-      int: (a => a)(inp##int),
+      \\"int\\": (a => a)(inp##int),
 
-      nullableFloat:
+      \\"nullableFloat\\":
         (
           a =>
             switch (a) {
@@ -11275,9 +11275,9 @@ module MyQuery = {
           inp##nullableFloat,
         ),
 
-      float: (a => a)(inp##float),
+      \\"float\\": (a => a)(inp##float),
 
-      nullableBoolean:
+      \\"nullableBoolean\\":
         (
           a =>
             switch (a) {
@@ -11288,9 +11288,9 @@ module MyQuery = {
           inp##nullableBoolean,
         ),
 
-      boolean: (a => a)(inp##boolean),
+      \\"boolean\\": (a => a)(inp##boolean),
 
-      nullableID:
+      \\"nullableID\\":
         (
           a =>
             switch (a) {
@@ -11301,7 +11301,7 @@ module MyQuery = {
           inp##nullableID,
         ),
 
-      id: (a => a)(inp##id),
+      \\"id\\": (a => a)(inp##id),
     };
   let make =
       (
@@ -11469,14 +11469,14 @@ module MyQuery = {
   let rec serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      arg: (a => serializeInputObjectVariousScalarsInput(a))(inp##arg),
+      \\"arg\\": (a => serializeInputObjectVariousScalarsInput(a))(inp##arg),
     }
 
   and serializeInputObjectVariousScalarsInput:
     t_variables_VariousScalarsInput => Raw.t_variables_VariousScalarsInput =
     inp => {
 
-      nullableString:
+      \\"nullableString\\":
         (
           a =>
             switch (a) {
@@ -11487,9 +11487,9 @@ module MyQuery = {
           inp##nullableString,
         ),
 
-      string: (a => a)(inp##string),
+      \\"string\\": (a => a)(inp##string),
 
-      nullableInt:
+      \\"nullableInt\\":
         (
           a =>
             switch (a) {
@@ -11500,9 +11500,9 @@ module MyQuery = {
           inp##nullableInt,
         ),
 
-      int: (a => a)(inp##int),
+      \\"int\\": (a => a)(inp##int),
 
-      nullableFloat:
+      \\"nullableFloat\\":
         (
           a =>
             switch (a) {
@@ -11513,9 +11513,9 @@ module MyQuery = {
           inp##nullableFloat,
         ),
 
-      float: (a => a)(inp##float),
+      \\"float\\": (a => a)(inp##float),
 
-      nullableBoolean:
+      \\"nullableBoolean\\":
         (
           a =>
             switch (a) {
@@ -11526,9 +11526,9 @@ module MyQuery = {
           inp##nullableBoolean,
         ),
 
-      boolean: (a => a)(inp##boolean),
+      \\"boolean\\": (a => a)(inp##boolean),
 
-      nullableID:
+      \\"nullableID\\":
         (
           a =>
             switch (a) {
@@ -11539,7 +11539,7 @@ module MyQuery = {
           inp##nullableID,
         ),
 
-      id: (a => a)(inp##id),
+      \\"id\\": (a => a)(inp##id),
     };
   let make = (~arg, ()) => {
     \\"query\\": query,
@@ -11763,7 +11763,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      var: (a => a)(inp##var),
+      \\"var\\": (a => a)(inp##var),
     };
   let make = (~var, ()) => {
     \\"query\\": query,
@@ -13638,7 +13638,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      query: (a => a)(inp##query),
+      \\"query\\": (a => a)(inp##query),
     };
   let makeVariables = (~query, ()) =>
     serializeVariables(
@@ -13721,16 +13721,16 @@ module MyQuery = {
   let rec serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      arg: (a => serializeInputObjectNonrecursiveInput(a))(inp##arg),
+      \\"arg\\": (a => serializeInputObjectNonrecursiveInput(a))(inp##arg),
     }
 
   and serializeInputObjectNonrecursiveInput:
     t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput =
     inp => {
 
-      nonNullableField: (a => a)(inp##nonNullableField),
+      \\"nonNullableField\\": (a => a)(inp##nonNullableField),
 
-      nullableArray:
+      \\"nullableArray\\":
         (
           a =>
             switch (a) {
@@ -13761,7 +13761,7 @@ module MyQuery = {
           inp##nullableArray,
         ),
 
-      field:
+      \\"field\\":
         (
           a =>
             switch (a) {
@@ -13772,7 +13772,7 @@ module MyQuery = {
           inp##field,
         ),
 
-      enum:
+      \\"enum\\":
         (
           a =>
             switch (a) {
@@ -13795,7 +13795,7 @@ module MyQuery = {
           inp##enum,
         ),
 
-      embeddedInput:
+      \\"embeddedInput\\":
         (
           a =>
             switch (a) {
@@ -13836,7 +13836,7 @@ module MyQuery = {
     t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput =
     inp => {
 
-      field:
+      \\"field\\":
         (
           a =>
             switch (a) {
@@ -14071,7 +14071,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      opt:
+      \\"opt\\":
         (
           a =>
             switch (a) {
@@ -14082,7 +14082,7 @@ module MyQuery = {
           inp##opt,
         ),
 
-      req: (a => a)(inp##req),
+      \\"req\\": (a => a)(inp##req),
     };
   let makeVariables = (~opt=?, ~req, ()) =>
     serializeVariables(
@@ -14278,7 +14278,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      arg:
+      \\"arg\\":
         (
           a =>
             switch (a) {
@@ -15293,7 +15293,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      nullableOfNullable:
+      \\"nullableOfNullable\\":
         (
           a =>
             switch (a) {
@@ -15324,7 +15324,7 @@ module MyQuery = {
           inp##nullableOfNullable,
         ),
 
-      nullableOfNonNullable:
+      \\"nullableOfNonNullable\\":
         (
           a =>
             switch (a) {
@@ -15336,7 +15336,7 @@ module MyQuery = {
           inp##nullableOfNonNullable,
         ),
 
-      nonNullableOfNullable:
+      \\"nonNullableOfNullable\\":
         (
           a =>
             Array.map(
@@ -15356,7 +15356,7 @@ module MyQuery = {
           inp##nonNullableOfNullable,
         ),
 
-      nonNullableOfNonNullable:
+      \\"nonNullableOfNonNullable\\":
         (a => Array.map(b => (a => a)(b), a))(
           inp##nonNullableOfNonNullable,
         ),
@@ -15450,14 +15450,14 @@ module MyQuery = {
   let rec serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      arg: (a => serializeInputObjectListsInput(a))(inp##arg),
+      \\"arg\\": (a => serializeInputObjectListsInput(a))(inp##arg),
     }
 
   and serializeInputObjectListsInput:
     t_variables_ListsInput => Raw.t_variables_ListsInput =
     inp => {
 
-      nullableOfNullable:
+      \\"nullableOfNullable\\":
         (
           a =>
             switch (a) {
@@ -15488,7 +15488,7 @@ module MyQuery = {
           inp##nullableOfNullable,
         ),
 
-      nullableOfNonNullable:
+      \\"nullableOfNonNullable\\":
         (
           a =>
             switch (a) {
@@ -15500,7 +15500,7 @@ module MyQuery = {
           inp##nullableOfNonNullable,
         ),
 
-      nonNullableOfNullable:
+      \\"nonNullableOfNullable\\":
         (
           a =>
             Array.map(
@@ -15520,7 +15520,7 @@ module MyQuery = {
           inp##nonNullableOfNullable,
         ),
 
-      nonNullableOfNonNullable:
+      \\"nonNullableOfNonNullable\\":
         (a => Array.map(b => (a => a)(b), a))(
           inp##nonNullableOfNonNullable,
         ),
@@ -15781,7 +15781,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      required: (a => a)(inp##required),
+      \\"required\\": (a => a)(inp##required),
     };
   let makeVariables = (~required, ()) =>
     serializeVariables(
@@ -15844,7 +15844,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      required: (a => a)(inp##required),
+      \\"required\\": (a => a)(inp##required),
     };
   let makeVariables = (~required, ()) =>
     serializeVariables(
@@ -16234,16 +16234,16 @@ module MyQuery = {
   let rec serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      arg: (a => serializeInputObjectNonrecursiveInput(a))(inp##arg),
+      \\"arg\\": (a => serializeInputObjectNonrecursiveInput(a))(inp##arg),
     }
 
   and serializeInputObjectNonrecursiveInput:
     t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput =
     inp => {
 
-      nonNullableField: (a => a)(inp##nonNullableField),
+      \\"nonNullableField\\": (a => a)(inp##nonNullableField),
 
-      nullableArray:
+      \\"nullableArray\\":
         (
           a =>
             switch (a) {
@@ -16274,7 +16274,7 @@ module MyQuery = {
           inp##nullableArray,
         ),
 
-      field:
+      \\"field\\":
         (
           a =>
             switch (a) {
@@ -16285,7 +16285,7 @@ module MyQuery = {
           inp##field,
         ),
 
-      enum:
+      \\"enum\\":
         (
           a =>
             switch (a) {
@@ -16308,7 +16308,7 @@ module MyQuery = {
           inp##enum,
         ),
 
-      embeddedInput:
+      \\"embeddedInput\\":
         (
           a =>
             switch (a) {
@@ -16349,7 +16349,7 @@ module MyQuery = {
     t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput =
     inp => {
 
-      field:
+      \\"field\\":
         (
           a =>
             switch (a) {
@@ -16607,7 +16607,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      id:
+      \\"id\\":
         (
           a =>
             switch (a) {
@@ -16618,7 +16618,7 @@ module MyQuery = {
           inp##id,
         ),
 
-      name:
+      \\"name\\":
         (
           a =>
             switch (a) {
@@ -17114,14 +17114,14 @@ module MyQuery = {
   let rec serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      arg: (a => serializeInputObjectRecursiveInput(a))(inp##arg),
+      \\"arg\\": (a => serializeInputObjectRecursiveInput(a))(inp##arg),
     }
 
   and serializeInputObjectRecursiveInput:
     t_variables_RecursiveInput => Raw.t_variables_RecursiveInput =
     inp => {
 
-      otherField:
+      \\"otherField\\":
         (
           a =>
             switch (a) {
@@ -17132,7 +17132,7 @@ module MyQuery = {
           inp##otherField,
         ),
 
-      inner:
+      \\"inner\\":
         (
           a =>
             switch (a) {
@@ -17146,7 +17146,7 @@ module MyQuery = {
           inp##inner,
         ),
 
-      enum:
+      \\"enum\\":
         (
           a =>
             switch (a) {
@@ -17479,7 +17479,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      nullableString:
+      \\"nullableString\\":
         (
           a =>
             switch (a) {
@@ -17490,9 +17490,9 @@ module MyQuery = {
           inp##nullableString,
         ),
 
-      string: (a => a)(inp##string),
+      \\"string\\": (a => a)(inp##string),
 
-      nullableInt:
+      \\"nullableInt\\":
         (
           a =>
             switch (a) {
@@ -17503,9 +17503,9 @@ module MyQuery = {
           inp##nullableInt,
         ),
 
-      int: (a => a)(inp##int),
+      \\"int\\": (a => a)(inp##int),
 
-      nullableFloat:
+      \\"nullableFloat\\":
         (
           a =>
             switch (a) {
@@ -17516,9 +17516,9 @@ module MyQuery = {
           inp##nullableFloat,
         ),
 
-      float: (a => a)(inp##float),
+      \\"float\\": (a => a)(inp##float),
 
-      nullableBoolean:
+      \\"nullableBoolean\\":
         (
           a =>
             switch (a) {
@@ -17529,9 +17529,9 @@ module MyQuery = {
           inp##nullableBoolean,
         ),
 
-      boolean: (a => a)(inp##boolean),
+      \\"boolean\\": (a => a)(inp##boolean),
 
-      nullableID:
+      \\"nullableID\\":
         (
           a =>
             switch (a) {
@@ -17542,7 +17542,7 @@ module MyQuery = {
           inp##nullableID,
         ),
 
-      id: (a => a)(inp##id),
+      \\"id\\": (a => a)(inp##id),
     };
   let makeVariables =
       (
@@ -17663,14 +17663,14 @@ module MyQuery = {
   let rec serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      arg: (a => serializeInputObjectVariousScalarsInput(a))(inp##arg),
+      \\"arg\\": (a => serializeInputObjectVariousScalarsInput(a))(inp##arg),
     }
 
   and serializeInputObjectVariousScalarsInput:
     t_variables_VariousScalarsInput => Raw.t_variables_VariousScalarsInput =
     inp => {
 
-      nullableString:
+      \\"nullableString\\":
         (
           a =>
             switch (a) {
@@ -17681,9 +17681,9 @@ module MyQuery = {
           inp##nullableString,
         ),
 
-      string: (a => a)(inp##string),
+      \\"string\\": (a => a)(inp##string),
 
-      nullableInt:
+      \\"nullableInt\\":
         (
           a =>
             switch (a) {
@@ -17694,9 +17694,9 @@ module MyQuery = {
           inp##nullableInt,
         ),
 
-      int: (a => a)(inp##int),
+      \\"int\\": (a => a)(inp##int),
 
-      nullableFloat:
+      \\"nullableFloat\\":
         (
           a =>
             switch (a) {
@@ -17707,9 +17707,9 @@ module MyQuery = {
           inp##nullableFloat,
         ),
 
-      float: (a => a)(inp##float),
+      \\"float\\": (a => a)(inp##float),
 
-      nullableBoolean:
+      \\"nullableBoolean\\":
         (
           a =>
             switch (a) {
@@ -17720,9 +17720,9 @@ module MyQuery = {
           inp##nullableBoolean,
         ),
 
-      boolean: (a => a)(inp##boolean),
+      \\"boolean\\": (a => a)(inp##boolean),
 
-      nullableID:
+      \\"nullableID\\":
         (
           a =>
             switch (a) {
@@ -17733,7 +17733,7 @@ module MyQuery = {
           inp##nullableID,
         ),
 
-      id: (a => a)(inp##id),
+      \\"id\\": (a => a)(inp##id),
     };
   let makeVariables = (~arg, ()) =>
     serializeVariables(
@@ -17941,7 +17941,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      var: (a => a)(inp##var),
+      \\"var\\": (a => a)(inp##var),
     };
   let makeVariables = (~var, ()) =>
     serializeVariables(
@@ -22054,7 +22054,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      required: (a => a)(inp##required),
+      \\"required\\": (a => a)(inp##required),
     };
   let makeVariables = (~required, ()) =>
     serializeVariables(

--- a/tests_bucklescript/__tests__/__snapshots__/snapshots.bs.js.snap
+++ b/tests_bucklescript/__tests__/__snapshots__/snapshots.bs.js.snap
@@ -2511,6 +2511,69 @@ module MyQuery = {
 "
 `;
 
+exports[`Apollo mutationWithArgsAndNoRecords.re 1`] = `
+"[@ocaml.ppx.context
+  {
+    tool_name: \\"migrate_driver\\",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module MyQuery = {
+  module Raw = {
+    type t = {. \\"optionalInputArgs\\": string};
+    type t_variables = {. \\"required\\": string};
+  };
+  let query = \\"mutation MyMutation($required: String!)  {\\\\noptionalInputArgs(required: $required, anotherRequired: \\\\\\"val\\\\\\")  \\\\n}\\\\n\\";
+  type t = {. \\"optionalInputArgs\\": string};
+  type t_variables = {. \\"required\\": string};
+  let parse: Raw.t => t =
+    value => {
+      \\"optionalInputArgs\\": {
+        let value = value##optionalInputArgs;
+        value;
+      },
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let optionalInputArgs = {
+        let value = value##optionalInputArgs;
+
+        value;
+      };
+      {
+
+        \\"optionalInputArgs\\": optionalInputArgs,
+      };
+    };
+  let serializeVariables: t_variables => Raw.t_variables =
+    inp => {
+
+      required: (a => a)(inp##required),
+    };
+  let makeVariables = (~required, ()) =>
+    serializeVariables(
+      {
+
+        \\"required\\": required,
+      }: t_variables,
+    );
+  let definition = (parse, query, serialize);
+};
+"
+`;
+
 exports[`Apollo nested.re 1`] = `
 "[@ocaml.ppx.context
   {
@@ -9385,6 +9448,85 @@ module MyQuery = {
 "
 `;
 
+exports[`Legacy mutationWithArgsAndNoRecords.re 1`] = `
+"[@ocaml.ppx.context
+  {
+    tool_name: \\"migrate_driver\\",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module MyQuery = {
+  module Raw = {
+    type t = {. \\"optionalInputArgs\\": string};
+    type t_variables = {. \\"required\\": string};
+  };
+  let query = \\"mutation MyMutation($required: String!)  {\\\\noptionalInputArgs(required: $required, anotherRequired: \\\\\\"val\\\\\\")  \\\\n}\\\\n\\";
+  type t = {. \\"optionalInputArgs\\": string};
+  type t_variables = {. \\"required\\": string};
+  let parse: Raw.t => t =
+    value => {
+      \\"optionalInputArgs\\": {
+        let value = value##optionalInputArgs;
+        value;
+      },
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let optionalInputArgs = {
+        let value = value##optionalInputArgs;
+
+        value;
+      };
+      {
+
+        \\"optionalInputArgs\\": optionalInputArgs,
+      };
+    };
+  let serializeVariables: t_variables => Raw.t_variables =
+    inp => {
+
+      required: (a => a)(inp##required),
+    };
+  let make = (~required, ()) => {
+    \\"query\\": query,
+    \\"variables\\":
+      serializeVariables(
+        {
+
+          \\"required\\": required,
+        }: t_variables,
+      ),
+    \\"parse\\": parse,
+  }
+  and makeVariables = (~required, ()) =>
+    serializeVariables(
+      {
+
+        \\"required\\": required,
+      }: t_variables,
+    );
+  let makeWithVariables = variables => {
+    \\"query\\": query,
+    \\"variables\\": serializeVariables(variables),
+    \\"parse\\": parse,
+  };
+  let definition = (parse, query, serialize);
+};
+"
+`;
+
 exports[`Legacy nested.re 1`] = `
 "[@ocaml.ppx.context
   {
@@ -15653,6 +15795,69 @@ module MyQuery = {
 "
 `;
 
+exports[`Objects mutationWithArgsAndNoRecords.re 1`] = `
+"[@ocaml.ppx.context
+  {
+    tool_name: \\"migrate_driver\\",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module MyQuery = {
+  module Raw = {
+    type t = {. \\"optionalInputArgs\\": string};
+    type t_variables = {. \\"required\\": string};
+  };
+  let query = \\"mutation MyMutation($required: String!)  {\\\\noptionalInputArgs(required: $required, anotherRequired: \\\\\\"val\\\\\\")  \\\\n}\\\\n\\";
+  type t = {. \\"optionalInputArgs\\": string};
+  type t_variables = {. \\"required\\": string};
+  let parse: Raw.t => t =
+    value => {
+      \\"optionalInputArgs\\": {
+        let value = value##optionalInputArgs;
+        value;
+      },
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let optionalInputArgs = {
+        let value = value##optionalInputArgs;
+
+        value;
+      };
+      {
+
+        \\"optionalInputArgs\\": optionalInputArgs,
+      };
+    };
+  let serializeVariables: t_variables => Raw.t_variables =
+    inp => {
+
+      required: (a => a)(inp##required),
+    };
+  let makeVariables = (~required, ()) =>
+    serializeVariables(
+      {
+
+        \\"required\\": required,
+      }: t_variables,
+    );
+  let definition = (parse, query, serialize);
+};
+"
+`;
+
 exports[`Objects nested.re 1`] = `
 "[@ocaml.ppx.context
   {
@@ -21793,6 +21998,69 @@ module MyQuery = {
       {
 
         required: required,
+      }: t_variables,
+    );
+  let definition = (parse, query, serialize);
+};
+"
+`;
+
+exports[`Records mutationWithArgsAndNoRecords.re 1`] = `
+"[@ocaml.ppx.context
+  {
+    tool_name: \\"migrate_driver\\",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module MyQuery = {
+  module Raw = {
+    type t = {. \\"optionalInputArgs\\": string};
+    type t_variables = {. \\"required\\": string};
+  };
+  let query = \\"mutation MyMutation($required: String!)  {\\\\noptionalInputArgs(required: $required, anotherRequired: \\\\\\"val\\\\\\")  \\\\n}\\\\n\\";
+  type t = {. \\"optionalInputArgs\\": string};
+  type t_variables = {. \\"required\\": string};
+  let parse: Raw.t => t =
+    value => {
+      \\"optionalInputArgs\\": {
+        let value = value##optionalInputArgs;
+        value;
+      },
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let optionalInputArgs = {
+        let value = value##optionalInputArgs;
+
+        value;
+      };
+      {
+
+        \\"optionalInputArgs\\": optionalInputArgs,
+      };
+    };
+  let serializeVariables: t_variables => Raw.t_variables =
+    inp => {
+
+      required: (a => a)(inp##required),
+    };
+  let makeVariables = (~required, ()) =>
+    serializeVariables(
+      {
+
+        \\"required\\": required,
       }: t_variables,
     );
   let definition = (parse, query, serialize);

--- a/tests_bucklescript/operations/mutationWithArgsAndNoRecords.re
+++ b/tests_bucklescript/operations/mutationWithArgsAndNoRecords.re
@@ -1,0 +1,8 @@
+module MyQuery = [%graphql
+  {|
+  mutation MyMutation($required: String!) {
+    optionalInputArgs(required: $required, anotherRequired: "val")
+  }
+|};
+  {records: false}
+];

--- a/tests_bucklescript/static_snapshots/apollo-mode/operations/mutationWithArgsAndNoRecords.re
+++ b/tests_bucklescript/static_snapshots/apollo-mode/operations/mutationWithArgsAndNoRecords.re
@@ -46,7 +46,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      required: (a => a)(inp##required),
+      "required": (a => a)(inp##required),
     };
   let makeVariables = (~required, ()) =>
     serializeVariables(

--- a/tests_bucklescript/static_snapshots/apollo-mode/operations/mutationWithArgsAndNoRecords.re
+++ b/tests_bucklescript/static_snapshots/apollo-mode/operations/mutationWithArgsAndNoRecords.re
@@ -1,0 +1,59 @@
+[@ocaml.ppx.context
+  {
+    tool_name: "migrate_driver",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module MyQuery = {
+  module Raw = {
+    type t = {. "optionalInputArgs": string};
+    type t_variables = {. "required": string};
+  };
+  let query = "mutation MyMutation($required: String!)  {\noptionalInputArgs(required: $required, anotherRequired: \"val\")  \n}\n";
+  type t = {. "optionalInputArgs": string};
+  type t_variables = {. "required": string};
+  let parse: Raw.t => t =
+    value => {
+      "optionalInputArgs": {
+        let value = value##optionalInputArgs;
+        value;
+      },
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let optionalInputArgs = {
+        let value = value##optionalInputArgs;
+
+        value;
+      };
+      {
+
+        "optionalInputArgs": optionalInputArgs,
+      };
+    };
+  let serializeVariables: t_variables => Raw.t_variables =
+    inp => {
+
+      required: (a => a)(inp##required),
+    };
+  let makeVariables = (~required, ()) =>
+    serializeVariables(
+      {
+
+        "required": required,
+      }: t_variables,
+    );
+  let definition = (parse, query, serialize);
+};

--- a/tests_bucklescript/static_snapshots/legacy/operations/argNamedQuery.re
+++ b/tests_bucklescript/static_snapshots/legacy/operations/argNamedQuery.re
@@ -46,7 +46,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      query: (a => a)(inp##query),
+      "query": (a => a)(inp##query),
     };
   let make = (~query, ()) => {
     "query": query,

--- a/tests_bucklescript/static_snapshots/legacy/operations/comment.re
+++ b/tests_bucklescript/static_snapshots/legacy/operations/comment.re
@@ -66,16 +66,16 @@ module MyQuery = {
   let rec serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      arg: (a => serializeInputObjectNonrecursiveInput(a))(inp##arg),
+      "arg": (a => serializeInputObjectNonrecursiveInput(a))(inp##arg),
     }
 
   and serializeInputObjectNonrecursiveInput:
     t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput =
     inp => {
 
-      nonNullableField: (a => a)(inp##nonNullableField),
+      "nonNullableField": (a => a)(inp##nonNullableField),
 
-      nullableArray:
+      "nullableArray":
         (
           a =>
             switch (a) {
@@ -106,7 +106,7 @@ module MyQuery = {
           inp##nullableArray,
         ),
 
-      field:
+      "field":
         (
           a =>
             switch (a) {
@@ -117,7 +117,7 @@ module MyQuery = {
           inp##field,
         ),
 
-      enum:
+      "enum":
         (
           a =>
             switch (a) {
@@ -140,7 +140,7 @@ module MyQuery = {
           inp##enum,
         ),
 
-      embeddedInput:
+      "embeddedInput":
         (
           a =>
             switch (a) {
@@ -181,7 +181,7 @@ module MyQuery = {
     t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput =
     inp => {
 
-      field:
+      "field":
         (
           a =>
             switch (a) {

--- a/tests_bucklescript/static_snapshots/legacy/operations/customScalars.re
+++ b/tests_bucklescript/static_snapshots/legacy/operations/customScalars.re
@@ -93,7 +93,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      opt:
+      "opt":
         (
           a =>
             switch (a) {
@@ -104,7 +104,7 @@ module MyQuery = {
           inp##opt,
         ),
 
-      req: (a => a)(inp##req),
+      "req": (a => a)(inp##req),
     };
   let make = (~opt=?, ~req, ()) => {
     "query": query,

--- a/tests_bucklescript/static_snapshots/legacy/operations/enumInput.re
+++ b/tests_bucklescript/static_snapshots/legacy/operations/enumInput.re
@@ -46,7 +46,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      arg:
+      "arg":
         (
           a =>
             switch (a) {

--- a/tests_bucklescript/static_snapshots/legacy/operations/listsArgs.re
+++ b/tests_bucklescript/static_snapshots/legacy/operations/listsArgs.re
@@ -58,7 +58,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      nullableOfNullable:
+      "nullableOfNullable":
         (
           a =>
             switch (a) {
@@ -89,7 +89,7 @@ module MyQuery = {
           inp##nullableOfNullable,
         ),
 
-      nullableOfNonNullable:
+      "nullableOfNonNullable":
         (
           a =>
             switch (a) {
@@ -101,7 +101,7 @@ module MyQuery = {
           inp##nullableOfNonNullable,
         ),
 
-      nonNullableOfNullable:
+      "nonNullableOfNullable":
         (
           a =>
             Array.map(
@@ -121,7 +121,7 @@ module MyQuery = {
           inp##nonNullableOfNullable,
         ),
 
-      nonNullableOfNonNullable:
+      "nonNullableOfNonNullable":
         (a => Array.map(b => (a => a)(b), a))(
           inp##nonNullableOfNonNullable,
         ),

--- a/tests_bucklescript/static_snapshots/legacy/operations/listsInput.re
+++ b/tests_bucklescript/static_snapshots/legacy/operations/listsInput.re
@@ -61,14 +61,14 @@ module MyQuery = {
   let rec serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      arg: (a => serializeInputObjectListsInput(a))(inp##arg),
+      "arg": (a => serializeInputObjectListsInput(a))(inp##arg),
     }
 
   and serializeInputObjectListsInput:
     t_variables_ListsInput => Raw.t_variables_ListsInput =
     inp => {
 
-      nullableOfNullable:
+      "nullableOfNullable":
         (
           a =>
             switch (a) {
@@ -99,7 +99,7 @@ module MyQuery = {
           inp##nullableOfNullable,
         ),
 
-      nullableOfNonNullable:
+      "nullableOfNonNullable":
         (
           a =>
             switch (a) {
@@ -111,7 +111,7 @@ module MyQuery = {
           inp##nullableOfNonNullable,
         ),
 
-      nonNullableOfNullable:
+      "nonNullableOfNullable":
         (
           a =>
             Array.map(
@@ -131,7 +131,7 @@ module MyQuery = {
           inp##nonNullableOfNullable,
         ),
 
-      nonNullableOfNonNullable:
+      "nonNullableOfNonNullable":
         (a => Array.map(b => (a => a)(b), a))(
           inp##nonNullableOfNonNullable,
         ),

--- a/tests_bucklescript/static_snapshots/legacy/operations/mutationWithArgs.re
+++ b/tests_bucklescript/static_snapshots/legacy/operations/mutationWithArgs.re
@@ -46,7 +46,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      required: (a => a)(inp##required),
+      "required": (a => a)(inp##required),
     };
   let make = (~required, ()) => {
     "query": query,

--- a/tests_bucklescript/static_snapshots/legacy/operations/mutationWithArgsAndNoRecords.re
+++ b/tests_bucklescript/static_snapshots/legacy/operations/mutationWithArgsAndNoRecords.re
@@ -46,7 +46,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      required: (a => a)(inp##required),
+      "required": (a => a)(inp##required),
     };
   let make = (~required, ()) => {
     "query": query,

--- a/tests_bucklescript/static_snapshots/legacy/operations/mutationWithArgsAndNoRecords.re
+++ b/tests_bucklescript/static_snapshots/legacy/operations/mutationWithArgsAndNoRecords.re
@@ -1,0 +1,75 @@
+[@ocaml.ppx.context
+  {
+    tool_name: "migrate_driver",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module MyQuery = {
+  module Raw = {
+    type t = {. "optionalInputArgs": string};
+    type t_variables = {. "required": string};
+  };
+  let query = "mutation MyMutation($required: String!)  {\noptionalInputArgs(required: $required, anotherRequired: \"val\")  \n}\n";
+  type t = {. "optionalInputArgs": string};
+  type t_variables = {. "required": string};
+  let parse: Raw.t => t =
+    value => {
+      "optionalInputArgs": {
+        let value = value##optionalInputArgs;
+        value;
+      },
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let optionalInputArgs = {
+        let value = value##optionalInputArgs;
+
+        value;
+      };
+      {
+
+        "optionalInputArgs": optionalInputArgs,
+      };
+    };
+  let serializeVariables: t_variables => Raw.t_variables =
+    inp => {
+
+      required: (a => a)(inp##required),
+    };
+  let make = (~required, ()) => {
+    "query": query,
+    "variables":
+      serializeVariables(
+        {
+
+          "required": required,
+        }: t_variables,
+      ),
+    "parse": parse,
+  }
+  and makeVariables = (~required, ()) =>
+    serializeVariables(
+      {
+
+        "required": required,
+      }: t_variables,
+    );
+  let makeWithVariables = variables => {
+    "query": query,
+    "variables": serializeVariables(variables),
+    "parse": parse,
+  };
+  let definition = (parse, query, serialize);
+};

--- a/tests_bucklescript/static_snapshots/legacy/operations/nonrecursiveInput.re
+++ b/tests_bucklescript/static_snapshots/legacy/operations/nonrecursiveInput.re
@@ -66,16 +66,16 @@ module MyQuery = {
   let rec serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      arg: (a => serializeInputObjectNonrecursiveInput(a))(inp##arg),
+      "arg": (a => serializeInputObjectNonrecursiveInput(a))(inp##arg),
     }
 
   and serializeInputObjectNonrecursiveInput:
     t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput =
     inp => {
 
-      nonNullableField: (a => a)(inp##nonNullableField),
+      "nonNullableField": (a => a)(inp##nonNullableField),
 
-      nullableArray:
+      "nullableArray":
         (
           a =>
             switch (a) {
@@ -106,7 +106,7 @@ module MyQuery = {
           inp##nullableArray,
         ),
 
-      field:
+      "field":
         (
           a =>
             switch (a) {
@@ -117,7 +117,7 @@ module MyQuery = {
           inp##field,
         ),
 
-      enum:
+      "enum":
         (
           a =>
             switch (a) {
@@ -140,7 +140,7 @@ module MyQuery = {
           inp##enum,
         ),
 
-      embeddedInput:
+      "embeddedInput":
         (
           a =>
             switch (a) {
@@ -181,7 +181,7 @@ module MyQuery = {
     t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput =
     inp => {
 
-      field:
+      "field":
         (
           a =>
             switch (a) {

--- a/tests_bucklescript/static_snapshots/legacy/operations/pokedexScalars.re
+++ b/tests_bucklescript/static_snapshots/legacy/operations/pokedexScalars.re
@@ -106,7 +106,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      id:
+      "id":
         (
           a =>
             switch (a) {
@@ -117,7 +117,7 @@ module MyQuery = {
           inp##id,
         ),
 
-      name:
+      "name":
         (
           a =>
             switch (a) {

--- a/tests_bucklescript/static_snapshots/legacy/operations/recursiveInput.re
+++ b/tests_bucklescript/static_snapshots/legacy/operations/recursiveInput.re
@@ -59,14 +59,14 @@ module MyQuery = {
   let rec serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      arg: (a => serializeInputObjectRecursiveInput(a))(inp##arg),
+      "arg": (a => serializeInputObjectRecursiveInput(a))(inp##arg),
     }
 
   and serializeInputObjectRecursiveInput:
     t_variables_RecursiveInput => Raw.t_variables_RecursiveInput =
     inp => {
 
-      otherField:
+      "otherField":
         (
           a =>
             switch (a) {
@@ -77,7 +77,7 @@ module MyQuery = {
           inp##otherField,
         ),
 
-      inner:
+      "inner":
         (
           a =>
             switch (a) {
@@ -91,7 +91,7 @@ module MyQuery = {
           inp##inner,
         ),
 
-      enum:
+      "enum":
         (
           a =>
             switch (a) {

--- a/tests_bucklescript/static_snapshots/legacy/operations/scalarsArgs.re
+++ b/tests_bucklescript/static_snapshots/legacy/operations/scalarsArgs.re
@@ -70,7 +70,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      nullableString:
+      "nullableString":
         (
           a =>
             switch (a) {
@@ -81,9 +81,9 @@ module MyQuery = {
           inp##nullableString,
         ),
 
-      string: (a => a)(inp##string),
+      "string": (a => a)(inp##string),
 
-      nullableInt:
+      "nullableInt":
         (
           a =>
             switch (a) {
@@ -94,9 +94,9 @@ module MyQuery = {
           inp##nullableInt,
         ),
 
-      int: (a => a)(inp##int),
+      "int": (a => a)(inp##int),
 
-      nullableFloat:
+      "nullableFloat":
         (
           a =>
             switch (a) {
@@ -107,9 +107,9 @@ module MyQuery = {
           inp##nullableFloat,
         ),
 
-      float: (a => a)(inp##float),
+      "float": (a => a)(inp##float),
 
-      nullableBoolean:
+      "nullableBoolean":
         (
           a =>
             switch (a) {
@@ -120,9 +120,9 @@ module MyQuery = {
           inp##nullableBoolean,
         ),
 
-      boolean: (a => a)(inp##boolean),
+      "boolean": (a => a)(inp##boolean),
 
-      nullableID:
+      "nullableID":
         (
           a =>
             switch (a) {
@@ -133,7 +133,7 @@ module MyQuery = {
           inp##nullableID,
         ),
 
-      id: (a => a)(inp##id),
+      "id": (a => a)(inp##id),
     };
   let make =
       (

--- a/tests_bucklescript/static_snapshots/legacy/operations/scalarsInput.re
+++ b/tests_bucklescript/static_snapshots/legacy/operations/scalarsInput.re
@@ -73,14 +73,14 @@ module MyQuery = {
   let rec serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      arg: (a => serializeInputObjectVariousScalarsInput(a))(inp##arg),
+      "arg": (a => serializeInputObjectVariousScalarsInput(a))(inp##arg),
     }
 
   and serializeInputObjectVariousScalarsInput:
     t_variables_VariousScalarsInput => Raw.t_variables_VariousScalarsInput =
     inp => {
 
-      nullableString:
+      "nullableString":
         (
           a =>
             switch (a) {
@@ -91,9 +91,9 @@ module MyQuery = {
           inp##nullableString,
         ),
 
-      string: (a => a)(inp##string),
+      "string": (a => a)(inp##string),
 
-      nullableInt:
+      "nullableInt":
         (
           a =>
             switch (a) {
@@ -104,9 +104,9 @@ module MyQuery = {
           inp##nullableInt,
         ),
 
-      int: (a => a)(inp##int),
+      "int": (a => a)(inp##int),
 
-      nullableFloat:
+      "nullableFloat":
         (
           a =>
             switch (a) {
@@ -117,9 +117,9 @@ module MyQuery = {
           inp##nullableFloat,
         ),
 
-      float: (a => a)(inp##float),
+      "float": (a => a)(inp##float),
 
-      nullableBoolean:
+      "nullableBoolean":
         (
           a =>
             switch (a) {
@@ -130,9 +130,9 @@ module MyQuery = {
           inp##nullableBoolean,
         ),
 
-      boolean: (a => a)(inp##boolean),
+      "boolean": (a => a)(inp##boolean),
 
-      nullableID:
+      "nullableID":
         (
           a =>
             switch (a) {
@@ -143,7 +143,7 @@ module MyQuery = {
           inp##nullableID,
         ),
 
-      id: (a => a)(inp##id),
+      "id": (a => a)(inp##id),
     };
   let make = (~arg, ()) => {
     "query": query,

--- a/tests_bucklescript/static_snapshots/legacy/operations/skipDirectives.re
+++ b/tests_bucklescript/static_snapshots/legacy/operations/skipDirectives.re
@@ -155,7 +155,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      var: (a => a)(inp##var),
+      "var": (a => a)(inp##var),
     };
   let make = (~var, ()) => {
     "query": query,

--- a/tests_bucklescript/static_snapshots/objects/operations/argNamedQuery.re
+++ b/tests_bucklescript/static_snapshots/objects/operations/argNamedQuery.re
@@ -46,7 +46,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      query: (a => a)(inp##query),
+      "query": (a => a)(inp##query),
     };
   let makeVariables = (~query, ()) =>
     serializeVariables(

--- a/tests_bucklescript/static_snapshots/objects/operations/comment.re
+++ b/tests_bucklescript/static_snapshots/objects/operations/comment.re
@@ -66,16 +66,16 @@ module MyQuery = {
   let rec serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      arg: (a => serializeInputObjectNonrecursiveInput(a))(inp##arg),
+      "arg": (a => serializeInputObjectNonrecursiveInput(a))(inp##arg),
     }
 
   and serializeInputObjectNonrecursiveInput:
     t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput =
     inp => {
 
-      nonNullableField: (a => a)(inp##nonNullableField),
+      "nonNullableField": (a => a)(inp##nonNullableField),
 
-      nullableArray:
+      "nullableArray":
         (
           a =>
             switch (a) {
@@ -106,7 +106,7 @@ module MyQuery = {
           inp##nullableArray,
         ),
 
-      field:
+      "field":
         (
           a =>
             switch (a) {
@@ -117,7 +117,7 @@ module MyQuery = {
           inp##field,
         ),
 
-      enum:
+      "enum":
         (
           a =>
             switch (a) {
@@ -140,7 +140,7 @@ module MyQuery = {
           inp##enum,
         ),
 
-      embeddedInput:
+      "embeddedInput":
         (
           a =>
             switch (a) {
@@ -181,7 +181,7 @@ module MyQuery = {
     t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput =
     inp => {
 
-      field:
+      "field":
         (
           a =>
             switch (a) {

--- a/tests_bucklescript/static_snapshots/objects/operations/customScalars.re
+++ b/tests_bucklescript/static_snapshots/objects/operations/customScalars.re
@@ -93,7 +93,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      opt:
+      "opt":
         (
           a =>
             switch (a) {
@@ -104,7 +104,7 @@ module MyQuery = {
           inp##opt,
         ),
 
-      req: (a => a)(inp##req),
+      "req": (a => a)(inp##req),
     };
   let makeVariables = (~opt=?, ~req, ()) =>
     serializeVariables(

--- a/tests_bucklescript/static_snapshots/objects/operations/enumInput.re
+++ b/tests_bucklescript/static_snapshots/objects/operations/enumInput.re
@@ -46,7 +46,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      arg:
+      "arg":
         (
           a =>
             switch (a) {

--- a/tests_bucklescript/static_snapshots/objects/operations/listsArgs.re
+++ b/tests_bucklescript/static_snapshots/objects/operations/listsArgs.re
@@ -58,7 +58,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      nullableOfNullable:
+      "nullableOfNullable":
         (
           a =>
             switch (a) {
@@ -89,7 +89,7 @@ module MyQuery = {
           inp##nullableOfNullable,
         ),
 
-      nullableOfNonNullable:
+      "nullableOfNonNullable":
         (
           a =>
             switch (a) {
@@ -101,7 +101,7 @@ module MyQuery = {
           inp##nullableOfNonNullable,
         ),
 
-      nonNullableOfNullable:
+      "nonNullableOfNullable":
         (
           a =>
             Array.map(
@@ -121,7 +121,7 @@ module MyQuery = {
           inp##nonNullableOfNullable,
         ),
 
-      nonNullableOfNonNullable:
+      "nonNullableOfNonNullable":
         (a => Array.map(b => (a => a)(b), a))(
           inp##nonNullableOfNonNullable,
         ),

--- a/tests_bucklescript/static_snapshots/objects/operations/listsInput.re
+++ b/tests_bucklescript/static_snapshots/objects/operations/listsInput.re
@@ -61,14 +61,14 @@ module MyQuery = {
   let rec serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      arg: (a => serializeInputObjectListsInput(a))(inp##arg),
+      "arg": (a => serializeInputObjectListsInput(a))(inp##arg),
     }
 
   and serializeInputObjectListsInput:
     t_variables_ListsInput => Raw.t_variables_ListsInput =
     inp => {
 
-      nullableOfNullable:
+      "nullableOfNullable":
         (
           a =>
             switch (a) {
@@ -99,7 +99,7 @@ module MyQuery = {
           inp##nullableOfNullable,
         ),
 
-      nullableOfNonNullable:
+      "nullableOfNonNullable":
         (
           a =>
             switch (a) {
@@ -111,7 +111,7 @@ module MyQuery = {
           inp##nullableOfNonNullable,
         ),
 
-      nonNullableOfNullable:
+      "nonNullableOfNullable":
         (
           a =>
             Array.map(
@@ -131,7 +131,7 @@ module MyQuery = {
           inp##nonNullableOfNullable,
         ),
 
-      nonNullableOfNonNullable:
+      "nonNullableOfNonNullable":
         (a => Array.map(b => (a => a)(b), a))(
           inp##nonNullableOfNonNullable,
         ),

--- a/tests_bucklescript/static_snapshots/objects/operations/mutationWithArgs.re
+++ b/tests_bucklescript/static_snapshots/objects/operations/mutationWithArgs.re
@@ -46,7 +46,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      required: (a => a)(inp##required),
+      "required": (a => a)(inp##required),
     };
   let makeVariables = (~required, ()) =>
     serializeVariables(

--- a/tests_bucklescript/static_snapshots/objects/operations/mutationWithArgsAndNoRecords.re
+++ b/tests_bucklescript/static_snapshots/objects/operations/mutationWithArgsAndNoRecords.re
@@ -46,7 +46,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      required: (a => a)(inp##required),
+      "required": (a => a)(inp##required),
     };
   let makeVariables = (~required, ()) =>
     serializeVariables(

--- a/tests_bucklescript/static_snapshots/objects/operations/mutationWithArgsAndNoRecords.re
+++ b/tests_bucklescript/static_snapshots/objects/operations/mutationWithArgsAndNoRecords.re
@@ -1,0 +1,59 @@
+[@ocaml.ppx.context
+  {
+    tool_name: "migrate_driver",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module MyQuery = {
+  module Raw = {
+    type t = {. "optionalInputArgs": string};
+    type t_variables = {. "required": string};
+  };
+  let query = "mutation MyMutation($required: String!)  {\noptionalInputArgs(required: $required, anotherRequired: \"val\")  \n}\n";
+  type t = {. "optionalInputArgs": string};
+  type t_variables = {. "required": string};
+  let parse: Raw.t => t =
+    value => {
+      "optionalInputArgs": {
+        let value = value##optionalInputArgs;
+        value;
+      },
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let optionalInputArgs = {
+        let value = value##optionalInputArgs;
+
+        value;
+      };
+      {
+
+        "optionalInputArgs": optionalInputArgs,
+      };
+    };
+  let serializeVariables: t_variables => Raw.t_variables =
+    inp => {
+
+      required: (a => a)(inp##required),
+    };
+  let makeVariables = (~required, ()) =>
+    serializeVariables(
+      {
+
+        "required": required,
+      }: t_variables,
+    );
+  let definition = (parse, query, serialize);
+};

--- a/tests_bucklescript/static_snapshots/objects/operations/nonrecursiveInput.re
+++ b/tests_bucklescript/static_snapshots/objects/operations/nonrecursiveInput.re
@@ -66,16 +66,16 @@ module MyQuery = {
   let rec serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      arg: (a => serializeInputObjectNonrecursiveInput(a))(inp##arg),
+      "arg": (a => serializeInputObjectNonrecursiveInput(a))(inp##arg),
     }
 
   and serializeInputObjectNonrecursiveInput:
     t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput =
     inp => {
 
-      nonNullableField: (a => a)(inp##nonNullableField),
+      "nonNullableField": (a => a)(inp##nonNullableField),
 
-      nullableArray:
+      "nullableArray":
         (
           a =>
             switch (a) {
@@ -106,7 +106,7 @@ module MyQuery = {
           inp##nullableArray,
         ),
 
-      field:
+      "field":
         (
           a =>
             switch (a) {
@@ -117,7 +117,7 @@ module MyQuery = {
           inp##field,
         ),
 
-      enum:
+      "enum":
         (
           a =>
             switch (a) {
@@ -140,7 +140,7 @@ module MyQuery = {
           inp##enum,
         ),
 
-      embeddedInput:
+      "embeddedInput":
         (
           a =>
             switch (a) {
@@ -181,7 +181,7 @@ module MyQuery = {
     t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput =
     inp => {
 
-      field:
+      "field":
         (
           a =>
             switch (a) {

--- a/tests_bucklescript/static_snapshots/objects/operations/pokedexScalars.re
+++ b/tests_bucklescript/static_snapshots/objects/operations/pokedexScalars.re
@@ -106,7 +106,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      id:
+      "id":
         (
           a =>
             switch (a) {
@@ -117,7 +117,7 @@ module MyQuery = {
           inp##id,
         ),
 
-      name:
+      "name":
         (
           a =>
             switch (a) {

--- a/tests_bucklescript/static_snapshots/objects/operations/recursiveInput.re
+++ b/tests_bucklescript/static_snapshots/objects/operations/recursiveInput.re
@@ -59,14 +59,14 @@ module MyQuery = {
   let rec serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      arg: (a => serializeInputObjectRecursiveInput(a))(inp##arg),
+      "arg": (a => serializeInputObjectRecursiveInput(a))(inp##arg),
     }
 
   and serializeInputObjectRecursiveInput:
     t_variables_RecursiveInput => Raw.t_variables_RecursiveInput =
     inp => {
 
-      otherField:
+      "otherField":
         (
           a =>
             switch (a) {
@@ -77,7 +77,7 @@ module MyQuery = {
           inp##otherField,
         ),
 
-      inner:
+      "inner":
         (
           a =>
             switch (a) {
@@ -91,7 +91,7 @@ module MyQuery = {
           inp##inner,
         ),
 
-      enum:
+      "enum":
         (
           a =>
             switch (a) {

--- a/tests_bucklescript/static_snapshots/objects/operations/scalarsArgs.re
+++ b/tests_bucklescript/static_snapshots/objects/operations/scalarsArgs.re
@@ -70,7 +70,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      nullableString:
+      "nullableString":
         (
           a =>
             switch (a) {
@@ -81,9 +81,9 @@ module MyQuery = {
           inp##nullableString,
         ),
 
-      string: (a => a)(inp##string),
+      "string": (a => a)(inp##string),
 
-      nullableInt:
+      "nullableInt":
         (
           a =>
             switch (a) {
@@ -94,9 +94,9 @@ module MyQuery = {
           inp##nullableInt,
         ),
 
-      int: (a => a)(inp##int),
+      "int": (a => a)(inp##int),
 
-      nullableFloat:
+      "nullableFloat":
         (
           a =>
             switch (a) {
@@ -107,9 +107,9 @@ module MyQuery = {
           inp##nullableFloat,
         ),
 
-      float: (a => a)(inp##float),
+      "float": (a => a)(inp##float),
 
-      nullableBoolean:
+      "nullableBoolean":
         (
           a =>
             switch (a) {
@@ -120,9 +120,9 @@ module MyQuery = {
           inp##nullableBoolean,
         ),
 
-      boolean: (a => a)(inp##boolean),
+      "boolean": (a => a)(inp##boolean),
 
-      nullableID:
+      "nullableID":
         (
           a =>
             switch (a) {
@@ -133,7 +133,7 @@ module MyQuery = {
           inp##nullableID,
         ),
 
-      id: (a => a)(inp##id),
+      "id": (a => a)(inp##id),
     };
   let makeVariables =
       (

--- a/tests_bucklescript/static_snapshots/objects/operations/scalarsInput.re
+++ b/tests_bucklescript/static_snapshots/objects/operations/scalarsInput.re
@@ -73,14 +73,14 @@ module MyQuery = {
   let rec serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      arg: (a => serializeInputObjectVariousScalarsInput(a))(inp##arg),
+      "arg": (a => serializeInputObjectVariousScalarsInput(a))(inp##arg),
     }
 
   and serializeInputObjectVariousScalarsInput:
     t_variables_VariousScalarsInput => Raw.t_variables_VariousScalarsInput =
     inp => {
 
-      nullableString:
+      "nullableString":
         (
           a =>
             switch (a) {
@@ -91,9 +91,9 @@ module MyQuery = {
           inp##nullableString,
         ),
 
-      string: (a => a)(inp##string),
+      "string": (a => a)(inp##string),
 
-      nullableInt:
+      "nullableInt":
         (
           a =>
             switch (a) {
@@ -104,9 +104,9 @@ module MyQuery = {
           inp##nullableInt,
         ),
 
-      int: (a => a)(inp##int),
+      "int": (a => a)(inp##int),
 
-      nullableFloat:
+      "nullableFloat":
         (
           a =>
             switch (a) {
@@ -117,9 +117,9 @@ module MyQuery = {
           inp##nullableFloat,
         ),
 
-      float: (a => a)(inp##float),
+      "float": (a => a)(inp##float),
 
-      nullableBoolean:
+      "nullableBoolean":
         (
           a =>
             switch (a) {
@@ -130,9 +130,9 @@ module MyQuery = {
           inp##nullableBoolean,
         ),
 
-      boolean: (a => a)(inp##boolean),
+      "boolean": (a => a)(inp##boolean),
 
-      nullableID:
+      "nullableID":
         (
           a =>
             switch (a) {
@@ -143,7 +143,7 @@ module MyQuery = {
           inp##nullableID,
         ),
 
-      id: (a => a)(inp##id),
+      "id": (a => a)(inp##id),
     };
   let makeVariables = (~arg, ()) =>
     serializeVariables(

--- a/tests_bucklescript/static_snapshots/objects/operations/skipDirectives.re
+++ b/tests_bucklescript/static_snapshots/objects/operations/skipDirectives.re
@@ -155,7 +155,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      var: (a => a)(inp##var),
+      "var": (a => a)(inp##var),
     };
   let makeVariables = (~var, ()) =>
     serializeVariables(

--- a/tests_bucklescript/static_snapshots/records/operations/mutationWithArgsAndNoRecords.re
+++ b/tests_bucklescript/static_snapshots/records/operations/mutationWithArgsAndNoRecords.re
@@ -46,7 +46,7 @@ module MyQuery = {
   let serializeVariables: t_variables => Raw.t_variables =
     inp => {
 
-      required: (a => a)(inp##required),
+      "required": (a => a)(inp##required),
     };
   let makeVariables = (~required, ()) =>
     serializeVariables(

--- a/tests_bucklescript/static_snapshots/records/operations/mutationWithArgsAndNoRecords.re
+++ b/tests_bucklescript/static_snapshots/records/operations/mutationWithArgsAndNoRecords.re
@@ -1,0 +1,59 @@
+[@ocaml.ppx.context
+  {
+    tool_name: "migrate_driver",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module MyQuery = {
+  module Raw = {
+    type t = {. "optionalInputArgs": string};
+    type t_variables = {. "required": string};
+  };
+  let query = "mutation MyMutation($required: String!)  {\noptionalInputArgs(required: $required, anotherRequired: \"val\")  \n}\n";
+  type t = {. "optionalInputArgs": string};
+  type t_variables = {. "required": string};
+  let parse: Raw.t => t =
+    value => {
+      "optionalInputArgs": {
+        let value = value##optionalInputArgs;
+        value;
+      },
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let optionalInputArgs = {
+        let value = value##optionalInputArgs;
+
+        value;
+      };
+      {
+
+        "optionalInputArgs": optionalInputArgs,
+      };
+    };
+  let serializeVariables: t_variables => Raw.t_variables =
+    inp => {
+
+      required: (a => a)(inp##required),
+    };
+  let makeVariables = (~required, ()) =>
+    serializeVariables(
+      {
+
+        "required": required,
+      }: t_variables,
+    );
+  let definition = (parse, query, serialize);
+};


### PR DESCRIPTION
When using objects, any passed in arguments to the query/mutation will break the GraphQL parsing. This adds an operation that shows how that fails.

One thing I saw is that the tests don't confirm that you can build the files in the `tests_bucklescript/operations/` folder. Only that the snapshot is correct. Such a test would fail with this PR.

Is that something that you want me to add?