### PR TITLE
Deprecated field alerts

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -332,6 +332,22 @@
               "deprecationReason": null
             },
             {
+              "name": "deprecatedFields",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "deprecatedFieldsResult",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "dogOrHuman",
               "description": null,
               "args": [],
@@ -1215,6 +1231,61 @@
           "fields": null,
           "inputFields": null,
           "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "deprecatedFieldsResult",
+          "description": null,
+          "fields": [
+            {
+              "name": "field1",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "field2",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecatedField",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use something else instead"
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": null
         },

--- a/schema.graphql
+++ b/schema.graphql
@@ -47,6 +47,7 @@ type Query {
     argRequired: CustomScalar!
   ): CustomScalarObject!
   customFields: customFieldsResult!
+  deprecatedFields: deprecatedFieldsResult!
 
   dogOrHuman: DogOrHuman!
 
@@ -189,4 +190,10 @@ type customFieldsResult {
   favoriteColor: Color!
   futureTime: DateTime
   nullableColor: Color
+}
+
+type deprecatedFieldsResult {
+  field1: String
+  field2: Int!
+  deprecatedField: String! @deprecated(reason: "Use something else instead")
 }

--- a/src/base/rule_deprecated_fields.re
+++ b/src/base/rule_deprecated_fields.re
@@ -1,0 +1,32 @@
+module Visitor: Traversal_utils.VisitorSig = {
+  open Traversal_utils;
+  open Source_pos;
+  open Graphql_ast;
+
+  include AbstractVisitor;
+
+  type t = unit;
+  let make_self = () => ();
+
+  let enter_field = (_, ctx, def) => {
+    let field_meta =
+      Context.parent_type(ctx)
+      |> Option.flat_map(t => Schema.lookup_field(t, def.item.fd_name.item));
+
+    field_meta
+    |> Option.map((field: Schema.field_meta) => {
+         switch (field.fm_deprecation_reason) {
+         | None => ()
+         | Some(reason) =>
+           let message =
+             Printf.sprintf(
+               "Field \"%s\" has been deprecated. Reason: %s",
+               field.fm_name,
+               reason,
+             );
+           Context.push_warning(ctx, def.span, message);
+         }
+       })
+    |> ignore;
+  };
+};

--- a/src/base/traversal_utils.re
+++ b/src/base/traversal_utils.re
@@ -6,6 +6,7 @@ type ctx = {
   fragments: Hashtbl.t(string, Graphql_ast.fragment),
   schema: Schema.t,
   errors: ref(list((Result_structure.loc, string))),
+  warnings: ref(list((Result_structure.loc, string))),
   type_stack: list(option(Schema.type_meta)),
   type_literal_stack: list(option(Schema.type_ref)),
   input_type_stack: list(option(Schema.type_meta)),
@@ -194,6 +195,8 @@ module Context = {
     };
   let push_error = (ctx, loc, msg) =>
     ctx.errors := [(ctx.map_loc(loc), msg), ...ctx.errors^];
+  let push_warning = (ctx, loc, msg) =>
+    ctx.warnings := [(ctx.map_loc(loc), msg), ...ctx.warnings^];
 };
 
 let rec as_schema_type_ref =
@@ -462,6 +465,7 @@ let make_context = (config, document) => {
   fragments: find_fragments(document),
   schema: config.Generator_utils.schema,
   errors: ref([]),
+  warnings: ref([]),
   type_stack: [],
   type_literal_stack: [],
   input_type_stack: [],

--- a/src/base/validations.re
+++ b/src/base/validations.re
@@ -12,7 +12,12 @@ module AllRulesImpl =
             (
               Multi_visitor.Visitor(
                 Rule_no_undefined_variables.Visitor,
-                Multi_visitor.NullVisitor,
+                (
+                  Multi_visitor.Visitor(
+                    Rule_deprecated_fields.Visitor,
+                    Multi_visitor.NullVisitor,
+                  )
+                ),
               )
             ),
           )
@@ -26,8 +31,11 @@ module AllRules = Visitor(AllRulesImpl);
 let run_validators = (config, document) => {
   let ctx = make_context(config, document);
   let _ = AllRules.visit_document(ctx, document);
-  switch (ctx.errors^) {
-  | [] => None
-  | errs => Some(errs)
-  };
+  (
+    switch (ctx.errors^) {
+    | [] => None
+    | errs => Some(errs)
+    },
+    ctx.warnings^,
+  );
 };

--- a/tests_bucklescript/__tests__/__snapshots__/snapshots.bs.js.snap
+++ b/tests_bucklescript/__tests__/__snapshots__/snapshots.bs.js.snap
@@ -6974,6 +6974,13 @@ module MyQuery = {
 "
 `;
 
+exports[`Errors deprecatedFields.re 1`] = `
+"File \\"operations/errors/deprecatedFields.re\\", line 7, characters 6-21:
+7 |       deprecatedField
+          ^^^^^^^^^^^^^^^
+Alert deprecated: Field \\"deprecatedField\\" has been deprecated. Reason: Use something else instead"
+`;
+
 exports[`Errors missingField1.re 1`] = `
 "File \\"operations/errors/missingField1.re\\", line 6, characters 6-27:
 6 |       thisFieldDoesNotExist

--- a/tests_bucklescript/__tests__/snapshots.re
+++ b/tests_bucklescript/__tests__/snapshots.re
@@ -8,6 +8,11 @@ type buffer;
 
 [@bs.module "child_process"]
 external execSync: (string, options) => buffer = "execSync";
+[@bs.module "child_process"]
+external exec:
+  (string, options, (Js.nullable(Js.t({..})), string, string) => unit) =>
+  unit =
+  "exec";
 [@bs.module "fs"]
 external readdirSync: string => array(string) = "readdirSync";
 
@@ -96,56 +101,62 @@ let tests =
   ->Belt.Array.keep(Js.String.endsWith(".re"));
 
 let run_bsc_with_ppx = (fileName, pathIn, pathOut) => {
-  let result =
-    try(
-      execSync(
-        {j|./node_modules/.bin/bsc -ppx ../_build/default/src/bucklescript_bin/bin.exe $pathIn/$fileName|j},
-        {cwd: resolve(dirname, "..")},
-      )
-      |> toString
-    ) {
-    | error =>
-      let stderr = Js.Exn.asJsExn(error)->Obj.magic##stderr##toString();
-      let lines = stderr |> Js.String.split("\n");
-      let stderr =
-        lines
-        |> Js.Array.reduce(
-             (p, ln) => {
-               p !== ""
-                 ? p ++ "\n" ++ ln
-                 : ln
-                   |> Js.String.includes("operations/")
-                   || ln
-                   |> Js.String.includes("found a bug for you")
-                     ? ln : p
-             },
-             "",
-           );
-      let cutPosition =
-        stderr
-        |> Js.String.indexOf("Error while running external preprocessor");
-      let to_ = cutPosition > (-1) ? cutPosition : stderr |> Js.String.length;
-      stderr |> Js.String.substring(~from=0, ~to_) |> Js.String.trim;
-    };
+  Js.Promise.make((~resolve as resolvePromise, ~reject as _) => {
+    exec(
+      {j|./node_modules/.bin/bsc -ppx ../_build/default/src/bucklescript_bin/bin.exe $pathIn/$fileName|j},
+      {cwd: resolve(dirname, "..")},
+      (_error, _stdout, stderr) => {
+        let result = {
+          let lines = stderr |> Js.String.split("\n");
+          let stderr =
+            lines
+            |> Js.Array.reduce(
+                 (p, ln) => {
+                   p !== ""
+                     ? p ++ "\n" ++ ln
+                     : ln
+                       |> Js.String.includes("operations/")
+                       || ln
+                       |> Js.String.includes("found a bug for you")
+                         ? ln : p
+                 },
+                 "",
+               );
+          let cutPosition =
+            stderr
+            |> Js.String.indexOf("Error while running external preprocessor");
+          let to_ =
+            cutPosition > (-1) ? cutPosition : stderr |> Js.String.length;
+          stderr |> Js.String.substring(~from=0, ~to_) |> Js.String.trim;
+        };
 
-  let newFileName =
-    (
-      fileName
-      |> Js.String.substring(~from=0, ~to_=(fileName |> Js.String.length) - 3)
+        let newFileName =
+          (
+            fileName
+            |> Js.String.substring(
+                 ~from=0,
+                 ~to_=(fileName |> Js.String.length) - 3,
+               )
+          )
+          ++ ".txt";
+        writeFileSync(
+          {j|static_snapshots/$pathOut/$newFileName|j},
+          result ++ "\n",
+        );
+        resolvePromise(. result);
+      },
     )
-    ++ ".txt";
-  writeFileSync({j|static_snapshots/$pathOut/$newFileName|j}, result ++ "\n");
-  result;
+  });
 };
 
 describe("Errors", () =>
   tests
   |> Array.iter(t => {
-       test(t, () =>
-         expect(
-           run_bsc_with_ppx(t, "operations/errors", "errors/operations"),
-         )
-         |> toMatchSnapshot
+       testPromise(t, () =>
+         run_bsc_with_ppx(t, "operations/errors", "errors/operations")
+         |> Js.Promise.then_(result =>
+              Js.Promise.resolve(expect(result) |> toMatchSnapshot)
+            )
        )
      })
 );

--- a/tests_bucklescript/operations/errors/deprecatedFields.re
+++ b/tests_bucklescript/operations/errors/deprecatedFields.re
@@ -1,0 +1,11 @@
+module MyQuery = [%graphql
+  {|
+  query {
+    deprecatedFields {
+      field1
+      field2
+      deprecatedField
+    }
+  }
+|}
+];

--- a/tests_bucklescript/static_snapshots/errors/operations/deprecatedFields.txt
+++ b/tests_bucklescript/static_snapshots/errors/operations/deprecatedFields.txt
@@ -1,0 +1,4 @@
+File "operations/errors/deprecatedFields.re", line 7, characters 6-21:
+7 |       deprecatedField
+          ^^^^^^^^^^^^^^^
+Alert deprecated: Field "deprecatedField" has been deprecated. Reason: Use something else instead


### PR DESCRIPTION
This improves the error snapshotting by making it async and therefore making it able to catch warnings/alerts if the compiler doesn't fail. (no way of doing this with `execSync`).

I probably handled this pretty badly: This is basically a copy of @romanschejbal's PR #74 .
As I was working on improving the error catching I saw your PR and thought I might be able to actually catch warnings too. I needed an example so I copied most of your code and implemented it as a `print_alert`, which seems to be the way to go for deprecation warnings (according to: https://caml.inria.fr/pub/docs/manual-ocaml/alerts.html).

Let me know if this is fine or if you would rather take the error snapshotting improvements and update #74 with it. Whatever works for you, as I've taken your already present work. 