### PR TITLE
Fix a type error for bsVariant serialization

### DIFF
--- a/src/bucklescript/output_bucklescript_serializer.re
+++ b/src/bucklescript/output_bucklescript_serializer.re
@@ -656,11 +656,11 @@ and generate_poly_variant_union_encoder =
 }
 and generate_poly_variant_selection_set_encoder =
     (config, loc, name, fields, path, definition) => [%expr
-  Js.Json.null
+  Obj.magic(Js.Json.null)
 ]
 and generate_poly_variant_interface_encoder =
     (config, loc, name, base, fragments, path, definition) => [%expr
-  Js.Json.null
+  Obj.magic(Js.Json.null)
 ]
 and generate_solo_fragment_spread_encorder =
     (config, loc, name, arguments, definition) => [%expr

--- a/tests_bucklescript/__tests__/__snapshots__/snapshots.bs.js.snap
+++ b/tests_bucklescript/__tests__/__snapshots__/snapshots.bs.js.snap
@@ -7975,7 +7975,7 @@ module MyQuery = {
       {
         let mutationForVariant = {
           let value = (value: t).mutationForVariant;
-          Js.Json.null;
+          Obj.magic(Js.Json.null);
         };
         {
 
@@ -15347,7 +15347,7 @@ module MyQuery = {
     value => {
       let mutationForVariant = {
         let value = value##mutationForVariant;
-        Js.Json.null;
+        Obj.magic(Js.Json.null);
       };
       {
 
@@ -22258,7 +22258,7 @@ module MyQuery = {
     value => {
       let mutationForVariant = {
         let value = value##mutationForVariant;
-        Js.Json.null;
+        Obj.magic(Js.Json.null);
       };
       {
 
@@ -29491,7 +29491,7 @@ module MyQuery = {
       {
         let mutationForVariant = {
           let value = (value: t).mutationForVariant;
-          Js.Json.null;
+          Obj.magic(Js.Json.null);
         };
         {
 

--- a/tests_bucklescript/static_snapshots/apollo-mode/operations/variant.re
+++ b/tests_bucklescript/static_snapshots/apollo-mode/operations/variant.re
@@ -279,7 +279,7 @@ module MyQuery = {
       {
         let mutationForVariant = {
           let value = (value: t).mutationForVariant;
-          Js.Json.null;
+          Obj.magic(Js.Json.null);
         };
         {
 

--- a/tests_bucklescript/static_snapshots/legacy/operations/variant.re
+++ b/tests_bucklescript/static_snapshots/legacy/operations/variant.re
@@ -218,7 +218,7 @@ module MyQuery = {
     value => {
       let mutationForVariant = {
         let value = value##mutationForVariant;
-        Js.Json.null;
+        Obj.magic(Js.Json.null);
       };
       {
 

--- a/tests_bucklescript/static_snapshots/objects/operations/variant.re
+++ b/tests_bucklescript/static_snapshots/objects/operations/variant.re
@@ -218,7 +218,7 @@ module MyQuery = {
     value => {
       let mutationForVariant = {
         let value = value##mutationForVariant;
-        Js.Json.null;
+        Obj.magic(Js.Json.null);
       };
       {
 

--- a/tests_bucklescript/static_snapshots/records/operations/variant.re
+++ b/tests_bucklescript/static_snapshots/records/operations/variant.re
@@ -237,7 +237,7 @@ module MyQuery = {
       {
         let mutationForVariant = {
           let value = (value: t).mutationForVariant;
-          Js.Json.null;
+          Obj.magic(Js.Json.null);
         };
         {
 


### PR DESCRIPTION
Just a small thing. I feel it's not an issue to `Obj.magic` these as they are not implemented to work anyway.