### PR TITLE
Future added value option

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,65 @@ In this example, `height` will be converted from a float to a string in the
 result. Using the `module` argument, you can specify any decoder module with
 the functions `parse`, `serialize` and type `t`.
 
+### Future added values in enums & union variants
+
+`graphql-ppx` will add the polymorphic variant `\`FutureAddedValue(value)` by default to both enum fields & union variants. This is in accordance to the graphql specification, in order to build robust clients against potentially changing server schemas.
+
+[Lee Byron](https://github.com/leebyron), the co-creator of graphql, says the [following](https://github.com/facebook/relay/issues/2351#issuecomment-368958022) about this topic:
+
+> These are generated as a reminder that GraphQL services often expand in capabilities and may return new enum values. To be future-proof, clients should account for this possibility and do something reasonable to avoid a broken product.
+
+Adding this variant is intentional default behaviour of the ppx, to avoid unintentional production bugs. You have however the option, to specifically opt-out of this behaviour and disable the generation of this additional variant. This could be useful, if you have absolute control over both the client and the server schema and are confident, that they may never be out of sync.
+
+To opt-out, you can specify the option `future_added_value: false`, either in your `bsconfig.json` (see [config](https://beta.graphql-ppx.com/docs/config)), or directly on your query.
+
+Example:
+
+```reason
+module ByConfig = [%graphql
+  {|
+    {
+      someQuery {
+        enumField
+      }
+    }
+|};
+  {future_added_value: false}
+];
+```
+
+The second way is to use the directive `@ppxOmitFutureValue` directly on your queried field.
+
+```reason
+module ByDirective = [%graphql
+  {|
+    {
+      someQuery {
+        enumField @ppxOmitFutureValue
+      }
+    }
+|}
+];
+```
+
+```reason
+// t_someQuery_enumField without config / directive
+type t_someQuery_enumField = [
+    | `FutureAddedValue(string)
+    | `FIRST
+    | `SECOND
+    | `THIRD
+  ];
+// t_someQuery_enumField with config / directive
+type t_someQuery_enumField = [
+    | `FIRST
+    | `SECOND
+    | `THIRD
+  ];
+```
+
+**Please note:** Decoding the raw query result while having the future value variant disabled, can lead to a `Not_found` exception being thrown if an unexpected result is received.
+
 ### Non-union variant conversion
 
 If you've got an object which in practice behaves like a variant - like `signUp`

--- a/src/base/extract_type_definitions.re
+++ b/src/base/extract_type_definitions.re
@@ -42,6 +42,7 @@ and type_def =
       loc: Source_pos.ast_location,
       path,
       fields: list((Result_structure.name, Result_structure.t)),
+      omit_future_value: bool,
     })
   | VariantInterface({
       loc: Source_pos.ast_location,
@@ -53,6 +54,7 @@ and type_def =
       loc: Source_pos.ast_location,
       path,
       fields: list(string),
+      omit_future_value: bool,
     });
 
 type input_object_field =
@@ -95,8 +97,8 @@ let rec extract = (~variant=false, ~path, ~raw) =>
       create_object(path, raw, fields, true, loc, variant)
     | (_, _, _) => create_object(path, raw, fields, false, loc, variant)
     }
-  | Res_poly_variant_union(loc, _name, fragments, _) => [
-      VariantUnion({path, fields: fragments, loc}),
+  | Res_poly_variant_union(loc, _name, fragments, _, omit_future_value) => [
+      VariantUnion({path, fields: fragments, loc, omit_future_value}),
       ...extract_fragments(
            fragments
            |> List.map((({item: name}: Result_structure.name, t)) =>
@@ -130,11 +132,12 @@ let rec extract = (~variant=false, ~path, ~raw) =>
   | Res_float(_loc) => []
   | Res_boolean(_loc) => []
   | Res_raw_scalar(_) => []
-  | Res_poly_enum(loc, enum_meta) => [
+  | Res_poly_enum(loc, enum_meta, omit_future_value) => [
       Enum({
         path,
         fields: enum_meta.em_values |> List.map(({evm_name, _}) => evm_name),
         loc,
+        omit_future_value,
       }),
     ]
 and fragment_names = f => f |> List.map(((name, _)) => name)

--- a/src/base/extract_type_definitions.rei
+++ b/src/base/extract_type_definitions.rei
@@ -36,6 +36,7 @@ and type_def =
       loc: Source_pos.ast_location,
       path,
       fields: list((Result_structure.name, Result_structure.t)),
+      omit_future_value: bool,
     })
   | VariantInterface({
       loc: Source_pos.ast_location,
@@ -47,6 +48,7 @@ and type_def =
       loc: Source_pos.ast_location,
       path,
       fields: list(string),
+      omit_future_value: bool,
     });
 
 type input_object_field =

--- a/src/base/generator_utils.re
+++ b/src/base/generator_utils.re
@@ -26,6 +26,7 @@ type output_config = {
   inline: bool,
   legacy: bool,
   definition: bool,
+  future_added_value: bool,
 };
 
 let filter_map = (f, l) => {

--- a/src/base/ppx_config.re
+++ b/src/base/ppx_config.re
@@ -17,6 +17,7 @@ type config = {
   template_tag_location: option(string),
   template_tag_import: option(string),
   custom_fields: Hashtbl.t(string, string),
+  future_added_value: bool,
 };
 
 let config_ref = ref(None);
@@ -31,6 +32,9 @@ let verbose_logging = () =>
 let output_mode = () => (config_ref^ |> Option.unsafe_unwrap).output_mode;
 
 let custom_fields = () => (config_ref^ |> Option.unsafe_unwrap).custom_fields;
+
+let future_added_value = () =>
+  (config_ref^ |> Option.unsafe_unwrap).future_added_value;
 
 let apollo_mode = () => (config_ref^ |> Option.unsafe_unwrap).apollo_mode;
 

--- a/src/base/result_decoder.re
+++ b/src/base/result_decoder.re
@@ -428,6 +428,9 @@ and unify_field = (error_marker, config, field_span, ty) => {
   let key = key.item;
   let is_variant = has_directive("bsVariant", ast_field.fd_directives);
   let is_record = has_directive("bsRecord", ast_field.fd_directives);
+  let is_omit_future_value =
+    has_directive("ppxOmitFutureValue", ast_field.fd_directives)
+    || !config.future_added_value;
   let existing_record = get_ppx_as(ast_field.fd_directives);
 
   let has_skip =

--- a/src/base/result_decoder.re
+++ b/src/base/result_decoder.re
@@ -81,6 +81,7 @@ let rec unify_type =
           error_marker,
           as_record,
           existing_record,
+          omit_future_value,
           config,
           span,
           ty,
@@ -94,6 +95,7 @@ let rec unify_type =
         error_marker,
         as_record,
         existing_record,
+        omit_future_value,
         config,
         span,
         t,
@@ -107,6 +109,7 @@ let rec unify_type =
         error_marker,
         as_record,
         existing_record,
+        omit_future_value,
         config,
         span,
         t,
@@ -147,7 +150,7 @@ let rec unify_type =
         selection_set,
       )
     | Some(Enum(enum_meta)) =>
-      Res_poly_enum(config.map_loc(span), enum_meta)
+      Res_poly_enum(config.map_loc(span), enum_meta, omit_future_value)
     | Some(Interface(im) as ty) =>
       unify_interface(
         error_marker,
@@ -166,7 +169,14 @@ let rec unify_type =
         "Can't have fields on input objects",
       )
     | Some(Union(um)) =>
-      unify_union(error_marker, config, span, um, selection_set)
+      unify_union(
+        error_marker,
+        config,
+        span,
+        um,
+        omit_future_value,
+        selection_set,
+      )
     }
   }
 and unify_interface =
@@ -239,7 +249,8 @@ and unify_interface =
       fragment_cases,
     );
   }
-and unify_union = (error_marker, config, span, union_meta, selection_set) =>
+and unify_union =
+    (error_marker, config, span, union_meta, omit_future_value, selection_set) =>
   switch (selection_set) {
   | None =>
     make_error(
@@ -318,6 +329,7 @@ and unify_union = (error_marker, config, span, union_meta, selection_set) =>
       } else {
         Nonexhaustive;
       },
+      omit_future_value,
     );
   }
 and unify_variant = (error_marker, config, span, ty, selection_set) =>
@@ -393,6 +405,7 @@ and unify_variant = (error_marker, config, span, ty, selection_set) =>
                        error_marker,
                        false,
                        None,
+                       false,
                        config,
                        span,
                        inner_type,
@@ -428,7 +441,7 @@ and unify_field = (error_marker, config, field_span, ty) => {
   let key = key.item;
   let is_variant = has_directive("bsVariant", ast_field.fd_directives);
   let is_record = has_directive("bsRecord", ast_field.fd_directives);
-  let is_omit_future_value =
+  let omit_future_value =
     has_directive("ppxOmitFutureValue", ast_field.fd_directives)
     || !config.future_added_value;
   let existing_record = get_ppx_as(ast_field.fd_directives);
@@ -440,7 +453,7 @@ and unify_field = (error_marker, config, field_span, ty) => {
     if (is_variant) {
       unify_variant(error_marker);
     } else {
-      unify_type(error_marker, is_record, existing_record);
+      unify_type(error_marker, is_record, existing_record, omit_future_value);
     };
 
   let parser_expr =

--- a/src/base/result_structure.re
+++ b/src/base/result_structure.re
@@ -22,12 +22,18 @@ and t =
   | Res_float(loc)
   | Res_boolean(loc)
   | Res_raw_scalar(loc)
-  | Res_poly_enum(loc, Schema.enum_meta)
+  | Res_poly_enum(loc, Schema.enum_meta, bool)
   | Res_custom_decoder(loc, string, t)
   | Res_record(loc, string, list(field_result), option(string))
   | Res_object(loc, string, list(field_result), option(string))
   | Res_poly_variant_selection_set(loc, string, list((name, t)))
-  | Res_poly_variant_union(loc, string, list((name, t)), exhaustive_flag)
+  | Res_poly_variant_union(
+      loc,
+      string,
+      list((name, t)),
+      exhaustive_flag,
+      bool,
+    )
   | Res_poly_variant_interface(loc, string, (string, t), list((string, t)))
   | Res_solo_fragment_spread(loc, string, list(string))
   | Res_error(loc, string);
@@ -57,12 +63,12 @@ let res_loc =
   | Res_float(loc)
   | Res_boolean(loc)
   | Res_raw_scalar(loc)
-  | Res_poly_enum(loc, _)
+  | Res_poly_enum(loc, _, _)
   | Res_custom_decoder(loc, _, _)
   | Res_record(loc, _, _, _)
   | Res_object(loc, _, _, _)
   | Res_poly_variant_selection_set(loc, _, _)
-  | Res_poly_variant_union(loc, _, _, _)
+  | Res_poly_variant_union(loc, _, _, _, _)
   | Res_poly_variant_interface(loc, _, _, _)
   | Res_solo_fragment_spread(loc, _, _)
   | Res_error(loc, _) => loc;

--- a/src/base/result_structure.rei
+++ b/src/base/result_structure.rei
@@ -22,12 +22,18 @@ and t =
   | Res_float(loc)
   | Res_boolean(loc)
   | Res_raw_scalar(loc)
-  | Res_poly_enum(loc, Schema.enum_meta)
+  | Res_poly_enum(loc, Schema.enum_meta, bool)
   | Res_custom_decoder(loc, string, t)
   | Res_record(loc, string, list(field_result), option(string))
   | Res_object(loc, string, list(field_result), option(string))
   | Res_poly_variant_selection_set(loc, string, list((name, t)))
-  | Res_poly_variant_union(loc, string, list((name, t)), exhaustive_flag)
+  | Res_poly_variant_union(
+      loc,
+      string,
+      list((name, t)),
+      exhaustive_flag,
+      bool,
+    )
   | Res_poly_variant_interface(loc, string, (string, t), list((string, t)))
   | Res_solo_fragment_spread(loc, string, list(string))
   | Res_error(loc, string);

--- a/src/bucklescript/bucklescript_config.re
+++ b/src/bucklescript/bucklescript_config.re
@@ -65,6 +65,7 @@ let defaultConfig =
     template_tag_import: None,
     definition: true,
     custom_fields: Hashtbl.create(0),
+    future_added_value: true,
   };
 
 module JsonHelper = {
@@ -113,6 +114,10 @@ let read_config = () => {
     ppxConfig
     |> JsonHelper.mapBool("verbose", verbose_logging => {
          Ppx_config.update_config(current => {...current, verbose_logging})
+       });
+    ppxConfig
+    |> JsonHelper.mapBool("future-added-value", future_added_value => {
+         Ppx_config.update_config(current => {...current, future_added_value})
        });
     ppxConfig
     |> JsonHelper.mapBool("apollo-mode", apollo_mode => {

--- a/src/bucklescript/graphql_ppx.re
+++ b/src/bucklescript/graphql_ppx.re
@@ -237,6 +237,8 @@ let extract_template_tag_import_from_config =
 let extract_records_from_config = extract_bool_from_config("records");
 let extract_objects_from_config = extract_bool_from_config("objects");
 let extract_inline_from_config = extract_bool_from_config("inline");
+let extract_future_added_value_from_config =
+  extract_bool_from_config("future_added_value");
 let extract_definition_from_config = extract_bool_from_config("definition");
 let extract_tagged_template_config =
   extract_bool_from_config("taggedTemplate");
@@ -251,6 +253,7 @@ type query_config = {
   template_tag_location: option(string),
   template_tag_import: option(string),
   tagged_template: option(bool),
+  future_added_value: option(bool),
 };
 
 let get_query_config = fields => {
@@ -264,6 +267,7 @@ let get_query_config = fields => {
     template_tag_import: extract_template_tag_import_from_config(fields),
     template_tag_location: extract_template_tag_location_from_config(fields),
     tagged_template: extract_tagged_template_config(fields),
+    future_added_value: extract_future_added_value_from_config(fields),
   };
 };
 let empty_query_config = {
@@ -276,6 +280,7 @@ let empty_query_config = {
   template_tag: None,
   template_tag_location: None,
   template_tag_import: None,
+  future_added_value: None,
 };
 
 let get_with_default = (value, default_value) => {
@@ -383,6 +388,11 @@ let rewrite_query =
           switch (query_config.inline) {
           | Some(value) => value
           | None => false
+          },
+        future_added_value:
+          switch (query_config.future_added_value) {
+          | Some(value) => value
+          | None => Ppx_config.future_added_value()
           },
         definition:
           switch (query_config.definition) {
@@ -633,6 +643,14 @@ let args = [
         ),
     ),
     "Defines if output string or AST",
+  ),
+  (
+    "-future-added-value",
+    Arg.Bool(
+      future_added_value =>
+        Ppx_config.update_config(current => {...current, future_added_value}),
+    ),
+    "Omits the `FutureAddedValue variant for enums if set to false",
   ),
   (
     "-o",

--- a/src/bucklescript/output_bucklescript_types.re
+++ b/src/bucklescript/output_bucklescript_types.re
@@ -77,7 +77,7 @@ let rec generate_type = (~atLoc=?, config, path, raw) =>
     | (_, _) => base_type(~loc=?atLoc, generate_type_name(path))
     }
   | Res_poly_variant_selection_set(loc, name, _)
-  | Res_poly_variant_union(loc, name, _, _)
+  | Res_poly_variant_union(loc, name, _, _, _)
   | Res_poly_variant_interface(loc, name, _, _) => {
       base_type(~loc=?atLoc, generate_type_name(path));
     }
@@ -89,7 +89,7 @@ let rec generate_type = (~atLoc=?, config, path, raw) =>
     }
   | Res_error(loc, error) =>
     raise(Location.Error(Location.error(~loc=conv_loc(loc), error)))
-  | Res_poly_enum(loc, enum_meta) =>
+  | Res_poly_enum(loc, enum_meta, _) =>
     base_type(~loc=?atLoc, generate_type_name(path));
 
 let wrap_type_declaration = (~manifest=?, inner, loc, path) => {
@@ -246,6 +246,7 @@ let generate_variant_union =
     (
       config,
       fields: list((Result_structure.name, Result_structure.t)),
+      omit_future_value,
       path,
       loc,
       raw,
@@ -253,18 +254,21 @@ let generate_variant_union =
   if (raw) {
     generate_opaque(path, loc);
   } else {
-    let fallback_case_ty = [
-      {
-        prf_desc:
-          Rtag(
-            {txt: "FutureAddedValue", loc: conv_loc(loc)},
-            false,
-            [base_type("Js.Json.t")],
-          ),
-        prf_loc: conv_loc(loc),
-        prf_attributes: [],
-      },
-    ];
+    let fallback_case_ty =
+      omit_future_value
+        ? []
+        : [
+          {
+            prf_desc:
+              Rtag(
+                {txt: "FutureAddedValue", loc: conv_loc(loc)},
+                false,
+                [base_type("Js.Json.t")],
+              ),
+            prf_loc: conv_loc(loc),
+            prf_attributes: [],
+          },
+        ];
 
     let fragment_case_tys =
       fields
@@ -334,7 +338,7 @@ let generate_variant_interface = (config, fields, base, path, loc, raw) =>
     );
   };
 
-let generate_enum = (config, fields, path, loc, raw) =>
+let generate_enum = (config, fields, path, loc, raw, omit_future_value) =>
   wrap_type_declaration(
     Ptype_abstract,
     ~manifest=
@@ -345,34 +349,35 @@ let generate_enum = (config, fields, path, loc, raw) =>
           [@metaloc conv_loc(loc)]
           Ast_helper.(
             Typ.variant(
-              [
-                {
-                  prf_desc:
-                    Rtag(
-                      {txt: "FutureAddedValue", loc: conv_loc(loc)},
-                      false,
-                      [base_type("string")],
-                    ),
-                  prf_loc: conv_loc(loc),
-                  prf_attributes: [],
-                },
-                ...fields
-                   |> List.map(field =>
-                        {
-                          prf_desc:
-                            Rtag(
-                              {
-                                txt: to_valid_ident(field),
-                                loc: conv_loc(loc),
-                              },
-                              true,
-                              [],
-                            ),
-                          prf_loc: conv_loc(loc),
-                          prf_attributes: [],
-                        }
-                      ),
-              ],
+              List.append(
+                omit_future_value
+                  ? []
+                  : [
+                    {
+                      prf_desc:
+                        Rtag(
+                          {txt: "FutureAddedValue", loc: conv_loc(loc)},
+                          false,
+                          [base_type("string")],
+                        ),
+                      prf_loc: conv_loc(loc),
+                      prf_attributes: [],
+                    },
+                  ],
+                fields
+                |> List.map(field =>
+                     {
+                       prf_desc:
+                         Rtag(
+                           {txt: to_valid_ident(field), loc: conv_loc(loc)},
+                           true,
+                           [],
+                         ),
+                       prf_loc: conv_loc(loc),
+                       prf_attributes: [],
+                     }
+                   ),
+              ),
               Closed,
               None,
             )
@@ -518,12 +523,19 @@ let generate_types =
            )
          | VariantSelection({loc, path, fields}) =>
            generate_variant_selection(config, fields, path, loc, raw)
-         | VariantUnion({loc, path, fields}) =>
-           generate_variant_union(config, fields, path, loc, raw)
+         | VariantUnion({loc, path, fields, omit_future_value}) =>
+           generate_variant_union(
+             config,
+             fields,
+             omit_future_value,
+             path,
+             loc,
+             raw,
+           )
          | VariantInterface({loc, path, base, fields}) =>
            generate_variant_interface(config, fields, base, path, loc, raw)
-         | Enum({loc, path, fields}) =>
-           generate_enum(config, fields, path, loc, raw),
+         | Enum({loc, path, fields, omit_future_value}) =>
+           generate_enum(config, fields, path, loc, raw, omit_future_value),
        )
     |> List.rev;
 

--- a/src/native/graphql_ppx.re
+++ b/src/native/graphql_ppx.re
@@ -131,6 +131,7 @@ let rewrite_query = (~schema=?, ~loc, ~delim, ~query, ()) => {
         inline: false,
         legacy: false,
         definition: true,
+        future_added_value: Ppx_config.future_added_value(),
       };
       switch (Validations.run_validators(config, document)) {
       | (Some(errs), _) =>
@@ -228,6 +229,7 @@ let () =
       template_tag_location: None,
       template_tag_import: None,
       custom_fields: Hashtbl.create(0),
+      future_added_value: true,
     })
   );
 
@@ -350,6 +352,14 @@ let args = [
         Ppx_config.update_config(current => {...current, schema_file}),
     ),
     "<path/to/schema.json>",
+  ),
+  (
+    "-future-added-value",
+    Arg.Bool(
+      future_added_value =>
+        Ppx_config.update_config(current => {...current, future_added_value}),
+    ),
+    "Omits the `FutureAddedValue variant for enums if set to false",
   ),
   (
     "-ast-out",

--- a/src/native/output_native_decoder.re
+++ b/src/native/output_native_decoder.re
@@ -168,7 +168,7 @@ let rec generate_decoder = config =>
   | Res_float(loc) => float_decoder(conv_loc(loc))
   | Res_boolean(loc) => boolean_decoder(conv_loc(loc))
   | Res_raw_scalar(_loc) => [%expr value]
-  | Res_poly_enum(loc, enum_meta) =>
+  | Res_poly_enum(loc, enum_meta, _) =>
     generate_poly_enum_decoder(conv_loc(loc), enum_meta)
   | Res_custom_decoder(loc, ident, inner) =>
     generate_custom_decoder(config, conv_loc(loc), ident, inner)
@@ -178,7 +178,7 @@ let rec generate_decoder = config =>
     generate_object_decoder(config, conv_loc(loc), name, fields)
   | Res_poly_variant_selection_set(loc, name, fields) =>
     generate_poly_variant_selection_set(config, conv_loc(loc), name, fields)
-  | Res_poly_variant_union(loc, name, fragments, exhaustive) =>
+  | Res_poly_variant_union(loc, name, fragments, exhaustive, _) =>
     generate_poly_variant_union(
       config,
       conv_loc(loc),

--- a/tests_bucklescript/__tests__/__snapshots__/snapshots.bs.js.snap
+++ b/tests_bucklescript/__tests__/__snapshots__/snapshots.bs.js.snap
@@ -3482,6 +3482,868 @@ NonrecursiveInput {
 "
 `;
 
+exports[`Apollo omitFutureValueEnum.re 1`] = `
+"[@ocaml.ppx.context
+  {
+    tool_name: \\"migrate_driver\\",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module Normal = {
+  module Raw = {
+    type t_mutationWithError_errors_field = string;
+    type t_mutationWithError_errors = {
+      __typename: string,
+      message: string,
+      field: t_mutationWithError_errors_field,
+    };
+    type t_mutationWithError = {
+      __typename: string,
+      errors: Js.Nullable.t(array(t_mutationWithError_errors)),
+    };
+    type t = {mutationWithError: t_mutationWithError};
+  };
+  let query = \\"mutation   {\\\\nmutationWithError  {\\\\n__typename  \\\\nerrors  {\\\\n__typename  \\\\nmessage  \\\\nfield  \\\\n}\\\\n\\\\n}\\\\n\\\\n}\\\\n\\";
+  type t_mutationWithError_errors_field = [
+    | \`FutureAddedValue(string)
+    | \`FIRST
+    | \`SECOND
+    | \`THIRD
+  ];
+  type t_mutationWithError_errors = {
+    __typename: string,
+    message: string,
+    field: t_mutationWithError_errors_field,
+  };
+  type t_mutationWithError = {
+    __typename: string,
+    errors: option(array(t_mutationWithError_errors)),
+  };
+  type t = {mutationWithError: t_mutationWithError};
+  type operation = t;
+  let parse: Raw.t => t =
+    (value) => (
+      {
+        mutationWithError: {
+          let value = (value: Raw.t).mutationWithError;
+          (
+            {
+              __typename: {
+                let value = (value: Raw.t_mutationWithError).__typename;
+                value;
+              },
+              errors: {
+                let value = (value: Raw.t_mutationWithError).errors;
+                switch (Js.toOption(value)) {
+                | Some(value) =>
+                  Some(
+                    value
+                    |> Js.Array.map((value) =>
+                         (
+                           {
+                             __typename: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).
+                                   __typename;
+                               value;
+                             },
+                             message: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).
+                                   message;
+                               value;
+                             },
+                             field: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).field;
+                               switch (Obj.magic(value: string)) {
+                               | \\"FIRST\\" => \`FIRST
+                               | \\"SECOND\\" => \`SECOND
+                               | \\"THIRD\\" => \`THIRD
+                               | other => \`FutureAddedValue(other)
+                               };
+                             },
+                           }: t_mutationWithError_errors
+                         )
+                       ),
+                  )
+                | None => None
+                };
+              },
+            }: t_mutationWithError
+          );
+        },
+      }: t
+    );
+  let serialize: t => Raw.t =
+    (value) => (
+      {
+        let mutationWithError = {
+          let value = (value: t).mutationWithError;
+          (
+            {
+              let errors = {
+                let value = (value: t_mutationWithError).errors;
+                switch (value) {
+                | Some(value) =>
+                  Js.Nullable.return(
+                    value
+                    |> Js.Array.map((value) =>
+                         (
+                           {
+                             let field = {
+                               let value =
+                                 (value: t_mutationWithError_errors).field;
+                               switch (value) {
+                               | \`FIRST => \\"FIRST\\"
+                               | \`SECOND => \\"SECOND\\"
+                               | \`THIRD => \\"THIRD\\"
+                               | \`FutureAddedValue(other) => other
+                               };
+                             }
+                             and message = {
+                               let value =
+                                 (value: t_mutationWithError_errors).message;
+                               value;
+                             }
+                             and __typename = {
+                               let value =
+                                 (value: t_mutationWithError_errors).
+                                   __typename;
+                               value;
+                             };
+                             {__typename, message, field};
+                           }: Raw.t_mutationWithError_errors
+                         )
+                       ),
+                  )
+                | None => Js.Nullable.null
+                };
+              }
+              and __typename = {
+                let value = (value: t_mutationWithError).__typename;
+                value;
+              };
+              {__typename, errors};
+            }: Raw.t_mutationWithError
+          );
+        };
+        {mutationWithError: mutationWithError};
+      }: Raw.t
+    );
+  let definition = (parse, query, serialize);
+};
+module ByConfig = {
+  module Raw = {
+    type t_mutationWithError_errors_field = string;
+    type t_mutationWithError_errors = {
+      __typename: string,
+      message: string,
+      field: t_mutationWithError_errors_field,
+    };
+    type t_mutationWithError = {
+      __typename: string,
+      errors: Js.Nullable.t(array(t_mutationWithError_errors)),
+    };
+    type t = {mutationWithError: t_mutationWithError};
+  };
+  let query = \\"mutation   {\\\\nmutationWithError  {\\\\n__typename  \\\\nerrors  {\\\\n__typename  \\\\nmessage  \\\\nfield  \\\\n}\\\\n\\\\n}\\\\n\\\\n}\\\\n\\";
+  type t_mutationWithError_errors_field = [ | \`FIRST | \`SECOND | \`THIRD];
+  type t_mutationWithError_errors = {
+    __typename: string,
+    message: string,
+    field: t_mutationWithError_errors_field,
+  };
+  type t_mutationWithError = {
+    __typename: string,
+    errors: option(array(t_mutationWithError_errors)),
+  };
+  type t = {mutationWithError: t_mutationWithError};
+  type operation = t;
+  let parse: Raw.t => t =
+    (value) => (
+      {
+        mutationWithError: {
+          let value = (value: Raw.t).mutationWithError;
+          (
+            {
+              __typename: {
+                let value = (value: Raw.t_mutationWithError).__typename;
+                value;
+              },
+              errors: {
+                let value = (value: Raw.t_mutationWithError).errors;
+                switch (Js.toOption(value)) {
+                | Some(value) =>
+                  Some(
+                    value
+                    |> Js.Array.map((value) =>
+                         (
+                           {
+                             __typename: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).
+                                   __typename;
+                               value;
+                             },
+                             message: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).
+                                   message;
+                               value;
+                             },
+                             field: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).field;
+                               switch (Obj.magic(value: string)) {
+                               | \\"FIRST\\" => \`FIRST
+                               | \\"SECOND\\" => \`SECOND
+                               | \\"THIRD\\" => \`THIRD
+                               | _ => raise(Not_found)
+                               };
+                             },
+                           }: t_mutationWithError_errors
+                         )
+                       ),
+                  )
+                | None => None
+                };
+              },
+            }: t_mutationWithError
+          );
+        },
+      }: t
+    );
+  let serialize: t => Raw.t =
+    (value) => (
+      {
+        let mutationWithError = {
+          let value = (value: t).mutationWithError;
+          (
+            {
+              let errors = {
+                let value = (value: t_mutationWithError).errors;
+                switch (value) {
+                | Some(value) =>
+                  Js.Nullable.return(
+                    value
+                    |> Js.Array.map((value) =>
+                         (
+                           {
+                             let field = {
+                               let value =
+                                 (value: t_mutationWithError_errors).field;
+                               switch (value) {
+                               | \`FIRST => \\"FIRST\\"
+                               | \`SECOND => \\"SECOND\\"
+                               | \`THIRD => \\"THIRD\\"
+                               };
+                             }
+                             and message = {
+                               let value =
+                                 (value: t_mutationWithError_errors).message;
+                               value;
+                             }
+                             and __typename = {
+                               let value =
+                                 (value: t_mutationWithError_errors).
+                                   __typename;
+                               value;
+                             };
+                             {__typename, message, field};
+                           }: Raw.t_mutationWithError_errors
+                         )
+                       ),
+                  )
+                | None => Js.Nullable.null
+                };
+              }
+              and __typename = {
+                let value = (value: t_mutationWithError).__typename;
+                value;
+              };
+              {__typename, errors};
+            }: Raw.t_mutationWithError
+          );
+        };
+        {mutationWithError: mutationWithError};
+      }: Raw.t
+    );
+  let definition = (parse, query, serialize);
+};
+module ByDirective = {
+  module Raw = {
+    type t_mutationWithError_errors_field = string;
+    type t_mutationWithError_errors = {
+      __typename: string,
+      message: string,
+      field: t_mutationWithError_errors_field,
+    };
+    type t_mutationWithError = {
+      __typename: string,
+      errors: Js.Nullable.t(array(t_mutationWithError_errors)),
+    };
+    type t = {mutationWithError: t_mutationWithError};
+  };
+  let query = \\"mutation   {\\\\nmutationWithError  {\\\\n__typename  \\\\nerrors  {\\\\n__typename  \\\\nmessage  \\\\nfield @ppxOmitFutureValue \\\\n}\\\\n\\\\n}\\\\n\\\\n}\\\\n\\";
+  type t_mutationWithError_errors_field = [ | \`FIRST | \`SECOND | \`THIRD];
+  type t_mutationWithError_errors = {
+    __typename: string,
+    message: string,
+    field: t_mutationWithError_errors_field,
+  };
+  type t_mutationWithError = {
+    __typename: string,
+    errors: option(array(t_mutationWithError_errors)),
+  };
+  type t = {mutationWithError: t_mutationWithError};
+  type operation = t;
+  let parse: Raw.t => t =
+    (value) => (
+      {
+        mutationWithError: {
+          let value = (value: Raw.t).mutationWithError;
+          (
+            {
+              __typename: {
+                let value = (value: Raw.t_mutationWithError).__typename;
+                value;
+              },
+              errors: {
+                let value = (value: Raw.t_mutationWithError).errors;
+                switch (Js.toOption(value)) {
+                | Some(value) =>
+                  Some(
+                    value
+                    |> Js.Array.map((value) =>
+                         (
+                           {
+                             __typename: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).
+                                   __typename;
+                               value;
+                             },
+                             message: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).
+                                   message;
+                               value;
+                             },
+                             field: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).field;
+                               switch (Obj.magic(value: string)) {
+                               | \\"FIRST\\" => \`FIRST
+                               | \\"SECOND\\" => \`SECOND
+                               | \\"THIRD\\" => \`THIRD
+                               | _ => raise(Not_found)
+                               };
+                             },
+                           }: t_mutationWithError_errors
+                         )
+                       ),
+                  )
+                | None => None
+                };
+              },
+            }: t_mutationWithError
+          );
+        },
+      }: t
+    );
+  let serialize: t => Raw.t =
+    (value) => (
+      {
+        let mutationWithError = {
+          let value = (value: t).mutationWithError;
+          (
+            {
+              let errors = {
+                let value = (value: t_mutationWithError).errors;
+                switch (value) {
+                | Some(value) =>
+                  Js.Nullable.return(
+                    value
+                    |> Js.Array.map((value) =>
+                         (
+                           {
+                             let field = {
+                               let value =
+                                 (value: t_mutationWithError_errors).field;
+                               switch (value) {
+                               | \`FIRST => \\"FIRST\\"
+                               | \`SECOND => \\"SECOND\\"
+                               | \`THIRD => \\"THIRD\\"
+                               };
+                             }
+                             and message = {
+                               let value =
+                                 (value: t_mutationWithError_errors).message;
+                               value;
+                             }
+                             and __typename = {
+                               let value =
+                                 (value: t_mutationWithError_errors).
+                                   __typename;
+                               value;
+                             };
+                             {__typename, message, field};
+                           }: Raw.t_mutationWithError_errors
+                         )
+                       ),
+                  )
+                | None => Js.Nullable.null
+                };
+              }
+              and __typename = {
+                let value = (value: t_mutationWithError).__typename;
+                value;
+              };
+              {__typename, errors};
+            }: Raw.t_mutationWithError
+          );
+        };
+        {mutationWithError: mutationWithError};
+      }: Raw.t
+    );
+  let definition = (parse, query, serialize);
+};
+"
+`;
+
+exports[`Apollo omitFutureValueUnion.re 1`] = `
+"[@ocaml.ppx.context
+  {
+    tool_name: \\"migrate_driver\\",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module Normal = {
+  module Raw = {
+    type t_dogOrHuman_Dog = {
+      __typename: string,
+      name: string,
+      barkVolume: float,
+    };
+    type t_dogOrHuman_Human = {
+      __typename: string,
+      name: string,
+    };
+    type t_dogOrHuman;
+    type t = {dogOrHuman: t_dogOrHuman};
+  };
+  let query = \\"query   {\\\\ndogOrHuman  {\\\\n__typename\\\\n...on Dog   {\\\\n__typename  \\\\nname  \\\\nbarkVolume  \\\\n}\\\\n\\\\n...on Human   {\\\\n__typename  \\\\nname  \\\\n}\\\\n\\\\n}\\\\n\\\\n}\\\\n\\";
+  type t_dogOrHuman_Dog = {
+    __typename: string,
+    name: string,
+    barkVolume: float,
+  };
+  type t_dogOrHuman_Human = {
+    __typename: string,
+    name: string,
+  };
+  type t_dogOrHuman = [
+    | \`FutureAddedValue(Js.Json.t)
+    | \`Dog(t_dogOrHuman_Dog)
+    | \`Human(t_dogOrHuman_Human)
+  ];
+  type t = {dogOrHuman: t_dogOrHuman};
+  type operation = t;
+  let parse: Raw.t => t =
+    (value) => (
+      {
+        dogOrHuman: {
+          let value = (value: Raw.t).dogOrHuman;
+          let typename: string =
+            Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), \\"__typename\\"));
+          (
+            switch (typename) {
+            | \\"Dog\\" =>
+              \`Dog(
+                {
+                  let value: Raw.t_dogOrHuman_Dog = Obj.magic(value);
+                  (
+                    {
+                      __typename: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).__typename;
+                        value;
+                      },
+                      name: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).name;
+                        value;
+                      },
+                      barkVolume: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).barkVolume;
+                        value;
+                      },
+                    }: t_dogOrHuman_Dog
+                  );
+                },
+              )
+            | \\"Human\\" =>
+              \`Human(
+                {
+                  let value: Raw.t_dogOrHuman_Human = Obj.magic(value);
+                  (
+                    {
+                      __typename: {
+                        let value = (value: Raw.t_dogOrHuman_Human).__typename;
+                        value;
+                      },
+                      name: {
+                        let value = (value: Raw.t_dogOrHuman_Human).name;
+                        value;
+                      },
+                    }: t_dogOrHuman_Human
+                  );
+                },
+              )
+            | _ => \`FutureAddedValue(Obj.magic(value): Js.Json.t)
+            }: t_dogOrHuman
+          );
+        },
+      }: t
+    );
+  let serialize: t => Raw.t =
+    (value) => (
+      {
+        let dogOrHuman = {
+          let value = (value: t).dogOrHuman;
+          switch (value) {
+          | \`Dog(value) => (
+              Obj.magic(
+                {
+                  let barkVolume = {
+                    let value = (value: t_dogOrHuman_Dog).barkVolume;
+                    value;
+                  }
+                  and name = {
+                    let value = (value: t_dogOrHuman_Dog).name;
+                    value;
+                  }
+                  and __typename = {
+                    let value = (value: t_dogOrHuman_Dog).__typename;
+                    value;
+                  };
+                  {__typename: \\"Dog\\", name, barkVolume};
+                }: Raw.t_dogOrHuman_Dog,
+              ): Raw.t_dogOrHuman
+            )
+          | \`Human(value) => (
+              Obj.magic(
+                {
+                  let name = {
+                    let value = (value: t_dogOrHuman_Human).name;
+                    value;
+                  }
+                  and __typename = {
+                    let value = (value: t_dogOrHuman_Human).__typename;
+                    value;
+                  };
+                  {__typename: \\"Human\\", name};
+                }: Raw.t_dogOrHuman_Human,
+              ): Raw.t_dogOrHuman
+            )
+          | \`FutureAddedValue(value) => (Obj.magic(value): Raw.t_dogOrHuman)
+          };
+        };
+        {dogOrHuman: dogOrHuman};
+      }: Raw.t
+    );
+  let definition = (parse, query, serialize);
+};
+module ByConfig = {
+  module Raw = {
+    type t_dogOrHuman_Dog = {
+      __typename: string,
+      name: string,
+      barkVolume: float,
+    };
+    type t_dogOrHuman_Human = {
+      __typename: string,
+      name: string,
+    };
+    type t_dogOrHuman;
+    type t = {dogOrHuman: t_dogOrHuman};
+  };
+  let query = \\"query   {\\\\ndogOrHuman  {\\\\n__typename\\\\n...on Dog   {\\\\n__typename  \\\\nname  \\\\nbarkVolume  \\\\n}\\\\n\\\\n...on Human   {\\\\n__typename  \\\\nname  \\\\n}\\\\n\\\\n}\\\\n\\\\n}\\\\n\\";
+  type t_dogOrHuman_Dog = {
+    __typename: string,
+    name: string,
+    barkVolume: float,
+  };
+  type t_dogOrHuman_Human = {
+    __typename: string,
+    name: string,
+  };
+  type t_dogOrHuman = [
+    | \`Dog(t_dogOrHuman_Dog)
+    | \`Human(t_dogOrHuman_Human)
+  ];
+  type t = {dogOrHuman: t_dogOrHuman};
+  type operation = t;
+  let parse: Raw.t => t =
+    (value) => (
+      {
+        dogOrHuman: {
+          let value = (value: Raw.t).dogOrHuman;
+          let typename: string =
+            Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), \\"__typename\\"));
+          (
+            switch (typename) {
+            | \\"Dog\\" =>
+              \`Dog(
+                {
+                  let value: Raw.t_dogOrHuman_Dog = Obj.magic(value);
+                  (
+                    {
+                      __typename: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).__typename;
+                        value;
+                      },
+                      name: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).name;
+                        value;
+                      },
+                      barkVolume: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).barkVolume;
+                        value;
+                      },
+                    }: t_dogOrHuman_Dog
+                  );
+                },
+              )
+            | \\"Human\\" =>
+              \`Human(
+                {
+                  let value: Raw.t_dogOrHuman_Human = Obj.magic(value);
+                  (
+                    {
+                      __typename: {
+                        let value = (value: Raw.t_dogOrHuman_Human).__typename;
+                        value;
+                      },
+                      name: {
+                        let value = (value: Raw.t_dogOrHuman_Human).name;
+                        value;
+                      },
+                    }: t_dogOrHuman_Human
+                  );
+                },
+              )
+            | _ => raise(Not_found)
+            }: t_dogOrHuman
+          );
+        },
+      }: t
+    );
+  let serialize: t => Raw.t =
+    (value) => (
+      {
+        let dogOrHuman = {
+          let value = (value: t).dogOrHuman;
+          switch (value) {
+          | \`Dog(value) => (
+              Obj.magic(
+                {
+                  let barkVolume = {
+                    let value = (value: t_dogOrHuman_Dog).barkVolume;
+                    value;
+                  }
+                  and name = {
+                    let value = (value: t_dogOrHuman_Dog).name;
+                    value;
+                  }
+                  and __typename = {
+                    let value = (value: t_dogOrHuman_Dog).__typename;
+                    value;
+                  };
+                  {__typename: \\"Dog\\", name, barkVolume};
+                }: Raw.t_dogOrHuman_Dog,
+              ): Raw.t_dogOrHuman
+            )
+          | \`Human(value) => (
+              Obj.magic(
+                {
+                  let name = {
+                    let value = (value: t_dogOrHuman_Human).name;
+                    value;
+                  }
+                  and __typename = {
+                    let value = (value: t_dogOrHuman_Human).__typename;
+                    value;
+                  };
+                  {__typename: \\"Human\\", name};
+                }: Raw.t_dogOrHuman_Human,
+              ): Raw.t_dogOrHuman
+            )
+          };
+        };
+        {dogOrHuman: dogOrHuman};
+      }: Raw.t
+    );
+  let definition = (parse, query, serialize);
+};
+module ByDirective = {
+  module Raw = {
+    type t_dogOrHuman_Dog = {
+      __typename: string,
+      name: string,
+      barkVolume: float,
+    };
+    type t_dogOrHuman_Human = {
+      __typename: string,
+      name: string,
+    };
+    type t_dogOrHuman;
+    type t = {dogOrHuman: t_dogOrHuman};
+  };
+  let query = \\"query   {\\\\ndogOrHuman @ppxOmitFutureValue {\\\\n__typename\\\\n...on Dog   {\\\\n__typename  \\\\nname  \\\\nbarkVolume  \\\\n}\\\\n\\\\n...on Human   {\\\\n__typename  \\\\nname  \\\\n}\\\\n\\\\n}\\\\n\\\\n}\\\\n\\";
+  type t_dogOrHuman_Dog = {
+    __typename: string,
+    name: string,
+    barkVolume: float,
+  };
+  type t_dogOrHuman_Human = {
+    __typename: string,
+    name: string,
+  };
+  type t_dogOrHuman = [
+    | \`Dog(t_dogOrHuman_Dog)
+    | \`Human(t_dogOrHuman_Human)
+  ];
+  type t = {dogOrHuman: t_dogOrHuman};
+  type operation = t;
+  let parse: Raw.t => t =
+    (value) => (
+      {
+        dogOrHuman: {
+          let value = (value: Raw.t).dogOrHuman;
+          let typename: string =
+            Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), \\"__typename\\"));
+          (
+            switch (typename) {
+            | \\"Dog\\" =>
+              \`Dog(
+                {
+                  let value: Raw.t_dogOrHuman_Dog = Obj.magic(value);
+                  (
+                    {
+                      __typename: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).__typename;
+                        value;
+                      },
+                      name: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).name;
+                        value;
+                      },
+                      barkVolume: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).barkVolume;
+                        value;
+                      },
+                    }: t_dogOrHuman_Dog
+                  );
+                },
+              )
+            | \\"Human\\" =>
+              \`Human(
+                {
+                  let value: Raw.t_dogOrHuman_Human = Obj.magic(value);
+                  (
+                    {
+                      __typename: {
+                        let value = (value: Raw.t_dogOrHuman_Human).__typename;
+                        value;
+                      },
+                      name: {
+                        let value = (value: Raw.t_dogOrHuman_Human).name;
+                        value;
+                      },
+                    }: t_dogOrHuman_Human
+                  );
+                },
+              )
+            | _ => raise(Not_found)
+            }: t_dogOrHuman
+          );
+        },
+      }: t
+    );
+  let serialize: t => Raw.t =
+    (value) => (
+      {
+        let dogOrHuman = {
+          let value = (value: t).dogOrHuman;
+          switch (value) {
+          | \`Dog(value) => (
+              Obj.magic(
+                {
+                  let barkVolume = {
+                    let value = (value: t_dogOrHuman_Dog).barkVolume;
+                    value;
+                  }
+                  and name = {
+                    let value = (value: t_dogOrHuman_Dog).name;
+                    value;
+                  }
+                  and __typename = {
+                    let value = (value: t_dogOrHuman_Dog).__typename;
+                    value;
+                  };
+                  {__typename: \\"Dog\\", name, barkVolume};
+                }: Raw.t_dogOrHuman_Dog,
+              ): Raw.t_dogOrHuman
+            )
+          | \`Human(value) => (
+              Obj.magic(
+                {
+                  let name = {
+                    let value = (value: t_dogOrHuman_Human).name;
+                    value;
+                  }
+                  and __typename = {
+                    let value = (value: t_dogOrHuman_Human).__typename;
+                    value;
+                  };
+                  {__typename: \\"Human\\", name};
+                }: Raw.t_dogOrHuman_Human,
+              ): Raw.t_dogOrHuman
+            )
+          };
+        };
+        {dogOrHuman: dogOrHuman};
+      }: Raw.t
+    );
+  let definition = (parse, query, serialize);
+};
+"
+`;
+
 exports[`Apollo pokedexApolloMode.re 1`] = `
 "[@ocaml.ppx.context
   {
@@ -10384,6 +11246,694 @@ NonrecursiveInput {
 "
 `;
 
+exports[`Legacy omitFutureValueEnum.re 1`] = `
+"[@ocaml.ppx.context
+  {
+    tool_name: \\"migrate_driver\\",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module Normal = {
+  module Raw = {
+    type t_mutationWithError_errors_field = string;
+    type t_mutationWithError_errors = {
+      .
+      \\"message\\": string,
+      \\"field\\": t_mutationWithError_errors_field,
+    };
+    type t_mutationWithError = {
+      .
+      \\"errors\\": Js.Nullable.t(array(t_mutationWithError_errors)),
+    };
+    type t = {. \\"mutationWithError\\": t_mutationWithError};
+  };
+  let query = \\"mutation   {\\\\nmutationWithError  {\\\\nerrors  {\\\\nmessage  \\\\nfield  \\\\n}\\\\n\\\\n}\\\\n\\\\n}\\\\n\\";
+  type t_mutationWithError_errors_field = [
+    | \`FutureAddedValue(string)
+    | \`FIRST
+    | \`SECOND
+    | \`THIRD
+  ];
+  type t_mutationWithError_errors = {
+    .
+    \\"message\\": string,
+    \\"field\\": t_mutationWithError_errors_field,
+  };
+  type t_mutationWithError = {
+    .
+    \\"errors\\": option(array(t_mutationWithError_errors)),
+  };
+  type t = {. \\"mutationWithError\\": t_mutationWithError};
+  type operation = t;
+  let parse: Raw.t => t =
+    value => {
+      let mutationWithError = {
+        let value = value##mutationWithError;
+        let errors = {
+          let value = value##errors;
+          switch (Js.toOption(value)) {
+          | Some(value) =>
+            Some(
+              value
+              |> Js.Array.map(value =>
+                   let field = {
+                     let value = value##field;
+                     switch (Obj.magic(value: string)) {
+                     | \\"FIRST\\" => \`FIRST
+                     | \\"SECOND\\" => \`SECOND
+                     | \\"THIRD\\" => \`THIRD
+                     | other => \`FutureAddedValue(other)
+                     };
+                   }
+                   and message = {
+                     let value = value##message;
+                     value;
+                   };
+                   {\\"message\\": message, \\"field\\": field};
+                 ),
+            )
+          | None => None
+          };
+        };
+        {\\"errors\\": errors};
+      };
+      {\\"mutationWithError\\": mutationWithError};
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let mutationWithError = {
+        let value = value##mutationWithError;
+        let errors = {
+          let value = value##errors;
+          switch (value) {
+          | Some(value) =>
+            Js.Nullable.return(
+              value
+              |> Js.Array.map(value =>
+                   let field = {
+                     let value = value##field;
+                     switch (value) {
+                     | \`FIRST => \\"FIRST\\"
+                     | \`SECOND => \\"SECOND\\"
+                     | \`THIRD => \\"THIRD\\"
+                     | \`FutureAddedValue(other) => other
+                     };
+                   }
+                   and message = {
+                     let value = value##message;
+                     value;
+                   };
+                   {\\"message\\": message, \\"field\\": field};
+                 ),
+            )
+          | None => Js.Nullable.null
+          };
+        };
+        {\\"errors\\": errors};
+      };
+      {\\"mutationWithError\\": mutationWithError};
+    };
+  let make = () => {
+    \\"query\\": query,
+    \\"variables\\": Js.Json.null,
+    \\"parse\\": parse,
+  };
+  let definition = (parse, query, serialize);
+};
+module ByConfig = {
+  module Raw = {
+    type t_mutationWithError_errors_field = string;
+    type t_mutationWithError_errors = {
+      .
+      \\"message\\": string,
+      \\"field\\": t_mutationWithError_errors_field,
+    };
+    type t_mutationWithError = {
+      .
+      \\"errors\\": Js.Nullable.t(array(t_mutationWithError_errors)),
+    };
+    type t = {. \\"mutationWithError\\": t_mutationWithError};
+  };
+  let query = \\"mutation   {\\\\nmutationWithError  {\\\\nerrors  {\\\\nmessage  \\\\nfield  \\\\n}\\\\n\\\\n}\\\\n\\\\n}\\\\n\\";
+  type t_mutationWithError_errors_field = [ | \`FIRST | \`SECOND | \`THIRD];
+  type t_mutationWithError_errors = {
+    .
+    \\"message\\": string,
+    \\"field\\": t_mutationWithError_errors_field,
+  };
+  type t_mutationWithError = {
+    .
+    \\"errors\\": option(array(t_mutationWithError_errors)),
+  };
+  type t = {. \\"mutationWithError\\": t_mutationWithError};
+  type operation = t;
+  let parse: Raw.t => t =
+    value => {
+      let mutationWithError = {
+        let value = value##mutationWithError;
+        let errors = {
+          let value = value##errors;
+          switch (Js.toOption(value)) {
+          | Some(value) =>
+            Some(
+              value
+              |> Js.Array.map(value =>
+                   let field = {
+                     let value = value##field;
+                     switch (Obj.magic(value: string)) {
+                     | \\"FIRST\\" => \`FIRST
+                     | \\"SECOND\\" => \`SECOND
+                     | \\"THIRD\\" => \`THIRD
+                     | _ => raise(Not_found)
+                     };
+                   }
+                   and message = {
+                     let value = value##message;
+                     value;
+                   };
+                   {\\"message\\": message, \\"field\\": field};
+                 ),
+            )
+          | None => None
+          };
+        };
+        {\\"errors\\": errors};
+      };
+      {\\"mutationWithError\\": mutationWithError};
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let mutationWithError = {
+        let value = value##mutationWithError;
+        let errors = {
+          let value = value##errors;
+          switch (value) {
+          | Some(value) =>
+            Js.Nullable.return(
+              value
+              |> Js.Array.map(value =>
+                   let field = {
+                     let value = value##field;
+                     switch (value) {
+                     | \`FIRST => \\"FIRST\\"
+                     | \`SECOND => \\"SECOND\\"
+                     | \`THIRD => \\"THIRD\\"
+                     };
+                   }
+                   and message = {
+                     let value = value##message;
+                     value;
+                   };
+                   {\\"message\\": message, \\"field\\": field};
+                 ),
+            )
+          | None => Js.Nullable.null
+          };
+        };
+        {\\"errors\\": errors};
+      };
+      {\\"mutationWithError\\": mutationWithError};
+    };
+  let make = () => {
+    \\"query\\": query,
+    \\"variables\\": Js.Json.null,
+    \\"parse\\": parse,
+  };
+  let definition = (parse, query, serialize);
+};
+module ByDirective = {
+  module Raw = {
+    type t_mutationWithError_errors_field = string;
+    type t_mutationWithError_errors = {
+      .
+      \\"message\\": string,
+      \\"field\\": t_mutationWithError_errors_field,
+    };
+    type t_mutationWithError = {
+      .
+      \\"errors\\": Js.Nullable.t(array(t_mutationWithError_errors)),
+    };
+    type t = {. \\"mutationWithError\\": t_mutationWithError};
+  };
+  let query = \\"mutation   {\\\\nmutationWithError  {\\\\nerrors  {\\\\nmessage  \\\\nfield @ppxOmitFutureValue \\\\n}\\\\n\\\\n}\\\\n\\\\n}\\\\n\\";
+  type t_mutationWithError_errors_field = [ | \`FIRST | \`SECOND | \`THIRD];
+  type t_mutationWithError_errors = {
+    .
+    \\"message\\": string,
+    \\"field\\": t_mutationWithError_errors_field,
+  };
+  type t_mutationWithError = {
+    .
+    \\"errors\\": option(array(t_mutationWithError_errors)),
+  };
+  type t = {. \\"mutationWithError\\": t_mutationWithError};
+  type operation = t;
+  let parse: Raw.t => t =
+    value => {
+      let mutationWithError = {
+        let value = value##mutationWithError;
+        let errors = {
+          let value = value##errors;
+          switch (Js.toOption(value)) {
+          | Some(value) =>
+            Some(
+              value
+              |> Js.Array.map(value =>
+                   let field = {
+                     let value = value##field;
+                     switch (Obj.magic(value: string)) {
+                     | \\"FIRST\\" => \`FIRST
+                     | \\"SECOND\\" => \`SECOND
+                     | \\"THIRD\\" => \`THIRD
+                     | _ => raise(Not_found)
+                     };
+                   }
+                   and message = {
+                     let value = value##message;
+                     value;
+                   };
+                   {\\"message\\": message, \\"field\\": field};
+                 ),
+            )
+          | None => None
+          };
+        };
+        {\\"errors\\": errors};
+      };
+      {\\"mutationWithError\\": mutationWithError};
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let mutationWithError = {
+        let value = value##mutationWithError;
+        let errors = {
+          let value = value##errors;
+          switch (value) {
+          | Some(value) =>
+            Js.Nullable.return(
+              value
+              |> Js.Array.map(value =>
+                   let field = {
+                     let value = value##field;
+                     switch (value) {
+                     | \`FIRST => \\"FIRST\\"
+                     | \`SECOND => \\"SECOND\\"
+                     | \`THIRD => \\"THIRD\\"
+                     };
+                   }
+                   and message = {
+                     let value = value##message;
+                     value;
+                   };
+                   {\\"message\\": message, \\"field\\": field};
+                 ),
+            )
+          | None => Js.Nullable.null
+          };
+        };
+        {\\"errors\\": errors};
+      };
+      {\\"mutationWithError\\": mutationWithError};
+    };
+  let make = () => {
+    \\"query\\": query,
+    \\"variables\\": Js.Json.null,
+    \\"parse\\": parse,
+  };
+  let definition = (parse, query, serialize);
+};
+"
+`;
+
+exports[`Legacy omitFutureValueUnion.re 1`] = `
+"[@ocaml.ppx.context
+  {
+    tool_name: \\"migrate_driver\\",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module Normal = {
+  module Raw = {
+    type t_dogOrHuman_Dog = {
+      .
+      \\"__typename\\": string,
+      \\"name\\": string,
+      \\"barkVolume\\": float,
+    };
+    type t_dogOrHuman_Human = {
+      .
+      \\"__typename\\": string,
+      \\"name\\": string,
+    };
+    type t_dogOrHuman;
+    type t = {. \\"dogOrHuman\\": t_dogOrHuman};
+  };
+  let query = \\"query   {\\\\ndogOrHuman  {\\\\n__typename\\\\n...on Dog   {\\\\nname  \\\\nbarkVolume  \\\\n}\\\\n\\\\n...on Human   {\\\\nname  \\\\n}\\\\n\\\\n}\\\\n\\\\n}\\\\n\\";
+  type t_dogOrHuman_Dog = {
+    .
+    \\"name\\": string,
+    \\"barkVolume\\": float,
+  };
+  type t_dogOrHuman_Human = {. \\"name\\": string};
+  type t_dogOrHuman = [
+    | \`FutureAddedValue(Js.Json.t)
+    | \`Dog(t_dogOrHuman_Dog)
+    | \`Human(t_dogOrHuman_Human)
+  ];
+  type t = {. \\"dogOrHuman\\": t_dogOrHuman};
+  type operation = t;
+  let parse: Raw.t => t =
+    value => {
+      let dogOrHuman = {
+        let value = value##dogOrHuman;
+        let typename: string =
+          Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), \\"__typename\\"));
+        (
+          switch (typename) {
+          | \\"Dog\\" =>
+            \`Dog(
+              {
+                let value: Raw.t_dogOrHuman_Dog = Obj.magic(value);
+                let barkVolume = {
+                  let value = value##barkVolume;
+                  value;
+                }
+                and name = {
+                  let value = value##name;
+                  value;
+                };
+                {\\"name\\": name, \\"barkVolume\\": barkVolume};
+              },
+            )
+          | \\"Human\\" =>
+            \`Human(
+              {
+                let value: Raw.t_dogOrHuman_Human = Obj.magic(value);
+                let name = {
+                  let value = value##name;
+                  value;
+                };
+                {\\"name\\": name};
+              },
+            )
+          | _ => \`FutureAddedValue(Obj.magic(value): Js.Json.t)
+          }: t_dogOrHuman
+        );
+      };
+      {\\"dogOrHuman\\": dogOrHuman};
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let dogOrHuman = {
+        let value = value##dogOrHuman;
+        switch (value) {
+        | \`Dog(value) => (
+            Obj.magic(
+              {
+                let barkVolume = {
+                  let value = value##barkVolume;
+                  value;
+                }
+                and name = {
+                  let value = value##name;
+                  value;
+                };
+                {\\"__typename\\": \\"Dog\\", \\"name\\": name, \\"barkVolume\\": barkVolume};
+              },
+            ): Raw.t_dogOrHuman
+          )
+        | \`Human(value) => (
+            Obj.magic(
+              {
+                let name = {
+                  let value = value##name;
+                  value;
+                };
+                {\\"__typename\\": \\"Human\\", \\"name\\": name};
+              },
+            ): Raw.t_dogOrHuman
+          )
+        | \`FutureAddedValue(value) => (Obj.magic(value): Raw.t_dogOrHuman)
+        };
+      };
+      {\\"dogOrHuman\\": dogOrHuman};
+    };
+  let make = () => {
+    \\"query\\": query,
+    \\"variables\\": Js.Json.null,
+    \\"parse\\": parse,
+  };
+  let definition = (parse, query, serialize);
+};
+module ByConfig = {
+  module Raw = {
+    type t_dogOrHuman_Dog = {
+      .
+      \\"__typename\\": string,
+      \\"name\\": string,
+      \\"barkVolume\\": float,
+    };
+    type t_dogOrHuman_Human = {
+      .
+      \\"__typename\\": string,
+      \\"name\\": string,
+    };
+    type t_dogOrHuman;
+    type t = {. \\"dogOrHuman\\": t_dogOrHuman};
+  };
+  let query = \\"query   {\\\\ndogOrHuman  {\\\\n__typename\\\\n...on Dog   {\\\\nname  \\\\nbarkVolume  \\\\n}\\\\n\\\\n...on Human   {\\\\nname  \\\\n}\\\\n\\\\n}\\\\n\\\\n}\\\\n\\";
+  type t_dogOrHuman_Dog = {
+    .
+    \\"name\\": string,
+    \\"barkVolume\\": float,
+  };
+  type t_dogOrHuman_Human = {. \\"name\\": string};
+  type t_dogOrHuman = [
+    | \`Dog(t_dogOrHuman_Dog)
+    | \`Human(t_dogOrHuman_Human)
+  ];
+  type t = {. \\"dogOrHuman\\": t_dogOrHuman};
+  type operation = t;
+  let parse: Raw.t => t =
+    value => {
+      let dogOrHuman = {
+        let value = value##dogOrHuman;
+        let typename: string =
+          Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), \\"__typename\\"));
+        (
+          switch (typename) {
+          | \\"Dog\\" =>
+            \`Dog(
+              {
+                let value: Raw.t_dogOrHuman_Dog = Obj.magic(value);
+                let barkVolume = {
+                  let value = value##barkVolume;
+                  value;
+                }
+                and name = {
+                  let value = value##name;
+                  value;
+                };
+                {\\"name\\": name, \\"barkVolume\\": barkVolume};
+              },
+            )
+          | \\"Human\\" =>
+            \`Human(
+              {
+                let value: Raw.t_dogOrHuman_Human = Obj.magic(value);
+                let name = {
+                  let value = value##name;
+                  value;
+                };
+                {\\"name\\": name};
+              },
+            )
+          | _ => raise(Not_found)
+          }: t_dogOrHuman
+        );
+      };
+      {\\"dogOrHuman\\": dogOrHuman};
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let dogOrHuman = {
+        let value = value##dogOrHuman;
+        switch (value) {
+        | \`Dog(value) => (
+            Obj.magic(
+              {
+                let barkVolume = {
+                  let value = value##barkVolume;
+                  value;
+                }
+                and name = {
+                  let value = value##name;
+                  value;
+                };
+                {\\"__typename\\": \\"Dog\\", \\"name\\": name, \\"barkVolume\\": barkVolume};
+              },
+            ): Raw.t_dogOrHuman
+          )
+        | \`Human(value) => (
+            Obj.magic(
+              {
+                let name = {
+                  let value = value##name;
+                  value;
+                };
+                {\\"__typename\\": \\"Human\\", \\"name\\": name};
+              },
+            ): Raw.t_dogOrHuman
+          )
+        };
+      };
+      {\\"dogOrHuman\\": dogOrHuman};
+    };
+  let make = () => {
+    \\"query\\": query,
+    \\"variables\\": Js.Json.null,
+    \\"parse\\": parse,
+  };
+  let definition = (parse, query, serialize);
+};
+module ByDirective = {
+  module Raw = {
+    type t_dogOrHuman_Dog = {
+      .
+      \\"__typename\\": string,
+      \\"name\\": string,
+      \\"barkVolume\\": float,
+    };
+    type t_dogOrHuman_Human = {
+      .
+      \\"__typename\\": string,
+      \\"name\\": string,
+    };
+    type t_dogOrHuman;
+    type t = {. \\"dogOrHuman\\": t_dogOrHuman};
+  };
+  let query = \\"query   {\\\\ndogOrHuman @ppxOmitFutureValue {\\\\n__typename\\\\n...on Dog   {\\\\nname  \\\\nbarkVolume  \\\\n}\\\\n\\\\n...on Human   {\\\\nname  \\\\n}\\\\n\\\\n}\\\\n\\\\n}\\\\n\\";
+  type t_dogOrHuman_Dog = {
+    .
+    \\"name\\": string,
+    \\"barkVolume\\": float,
+  };
+  type t_dogOrHuman_Human = {. \\"name\\": string};
+  type t_dogOrHuman = [
+    | \`Dog(t_dogOrHuman_Dog)
+    | \`Human(t_dogOrHuman_Human)
+  ];
+  type t = {. \\"dogOrHuman\\": t_dogOrHuman};
+  type operation = t;
+  let parse: Raw.t => t =
+    value => {
+      let dogOrHuman = {
+        let value = value##dogOrHuman;
+        let typename: string =
+          Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), \\"__typename\\"));
+        (
+          switch (typename) {
+          | \\"Dog\\" =>
+            \`Dog(
+              {
+                let value: Raw.t_dogOrHuman_Dog = Obj.magic(value);
+                let barkVolume = {
+                  let value = value##barkVolume;
+                  value;
+                }
+                and name = {
+                  let value = value##name;
+                  value;
+                };
+                {\\"name\\": name, \\"barkVolume\\": barkVolume};
+              },
+            )
+          | \\"Human\\" =>
+            \`Human(
+              {
+                let value: Raw.t_dogOrHuman_Human = Obj.magic(value);
+                let name = {
+                  let value = value##name;
+                  value;
+                };
+                {\\"name\\": name};
+              },
+            )
+          | _ => raise(Not_found)
+          }: t_dogOrHuman
+        );
+      };
+      {\\"dogOrHuman\\": dogOrHuman};
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let dogOrHuman = {
+        let value = value##dogOrHuman;
+        switch (value) {
+        | \`Dog(value) => (
+            Obj.magic(
+              {
+                let barkVolume = {
+                  let value = value##barkVolume;
+                  value;
+                }
+                and name = {
+                  let value = value##name;
+                  value;
+                };
+                {\\"__typename\\": \\"Dog\\", \\"name\\": name, \\"barkVolume\\": barkVolume};
+              },
+            ): Raw.t_dogOrHuman
+          )
+        | \`Human(value) => (
+            Obj.magic(
+              {
+                let name = {
+                  let value = value##name;
+                  value;
+                };
+                {\\"__typename\\": \\"Human\\", \\"name\\": name};
+              },
+            ): Raw.t_dogOrHuman
+          )
+        };
+      };
+      {\\"dogOrHuman\\": dogOrHuman};
+    };
+  let make = () => {
+    \\"query\\": query,
+    \\"variables\\": Js.Json.null,
+    \\"parse\\": parse,
+  };
+  let definition = (parse, query, serialize);
+};
+"
+`;
+
 exports[`Legacy pokedexApolloMode.re 1`] = `
 "[@ocaml.ppx.context
   {
@@ -16691,6 +18241,664 @@ NonrecursiveInput {
 "
 `;
 
+exports[`Objects omitFutureValueEnum.re 1`] = `
+"[@ocaml.ppx.context
+  {
+    tool_name: \\"migrate_driver\\",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module Normal = {
+  module Raw = {
+    type t_mutationWithError_errors_field = string;
+    type t_mutationWithError_errors = {
+      .
+      \\"message\\": string,
+      \\"field\\": t_mutationWithError_errors_field,
+    };
+    type t_mutationWithError = {
+      .
+      \\"errors\\": Js.Nullable.t(array(t_mutationWithError_errors)),
+    };
+    type t = {. \\"mutationWithError\\": t_mutationWithError};
+  };
+  let query = \\"mutation   {\\\\nmutationWithError  {\\\\nerrors  {\\\\nmessage  \\\\nfield  \\\\n}\\\\n\\\\n}\\\\n\\\\n}\\\\n\\";
+  type t_mutationWithError_errors_field = [
+    | \`FutureAddedValue(string)
+    | \`FIRST
+    | \`SECOND
+    | \`THIRD
+  ];
+  type t_mutationWithError_errors = {
+    .
+    \\"message\\": string,
+    \\"field\\": t_mutationWithError_errors_field,
+  };
+  type t_mutationWithError = {
+    .
+    \\"errors\\": option(array(t_mutationWithError_errors)),
+  };
+  type t = {. \\"mutationWithError\\": t_mutationWithError};
+  type operation = t;
+  let parse: Raw.t => t =
+    value => {
+      let mutationWithError = {
+        let value = value##mutationWithError;
+        let errors = {
+          let value = value##errors;
+          switch (Js.toOption(value)) {
+          | Some(value) =>
+            Some(
+              value
+              |> Js.Array.map(value =>
+                   let field = {
+                     let value = value##field;
+                     switch (Obj.magic(value: string)) {
+                     | \\"FIRST\\" => \`FIRST
+                     | \\"SECOND\\" => \`SECOND
+                     | \\"THIRD\\" => \`THIRD
+                     | other => \`FutureAddedValue(other)
+                     };
+                   }
+                   and message = {
+                     let value = value##message;
+                     value;
+                   };
+                   {\\"message\\": message, \\"field\\": field};
+                 ),
+            )
+          | None => None
+          };
+        };
+        {\\"errors\\": errors};
+      };
+      {\\"mutationWithError\\": mutationWithError};
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let mutationWithError = {
+        let value = value##mutationWithError;
+        let errors = {
+          let value = value##errors;
+          switch (value) {
+          | Some(value) =>
+            Js.Nullable.return(
+              value
+              |> Js.Array.map(value =>
+                   let field = {
+                     let value = value##field;
+                     switch (value) {
+                     | \`FIRST => \\"FIRST\\"
+                     | \`SECOND => \\"SECOND\\"
+                     | \`THIRD => \\"THIRD\\"
+                     | \`FutureAddedValue(other) => other
+                     };
+                   }
+                   and message = {
+                     let value = value##message;
+                     value;
+                   };
+                   {\\"message\\": message, \\"field\\": field};
+                 ),
+            )
+          | None => Js.Nullable.null
+          };
+        };
+        {\\"errors\\": errors};
+      };
+      {\\"mutationWithError\\": mutationWithError};
+    };
+  let definition = (parse, query, serialize);
+};
+module ByConfig = {
+  module Raw = {
+    type t_mutationWithError_errors_field = string;
+    type t_mutationWithError_errors = {
+      .
+      \\"message\\": string,
+      \\"field\\": t_mutationWithError_errors_field,
+    };
+    type t_mutationWithError = {
+      .
+      \\"errors\\": Js.Nullable.t(array(t_mutationWithError_errors)),
+    };
+    type t = {. \\"mutationWithError\\": t_mutationWithError};
+  };
+  let query = \\"mutation   {\\\\nmutationWithError  {\\\\nerrors  {\\\\nmessage  \\\\nfield  \\\\n}\\\\n\\\\n}\\\\n\\\\n}\\\\n\\";
+  type t_mutationWithError_errors_field = [ | \`FIRST | \`SECOND | \`THIRD];
+  type t_mutationWithError_errors = {
+    .
+    \\"message\\": string,
+    \\"field\\": t_mutationWithError_errors_field,
+  };
+  type t_mutationWithError = {
+    .
+    \\"errors\\": option(array(t_mutationWithError_errors)),
+  };
+  type t = {. \\"mutationWithError\\": t_mutationWithError};
+  type operation = t;
+  let parse: Raw.t => t =
+    value => {
+      let mutationWithError = {
+        let value = value##mutationWithError;
+        let errors = {
+          let value = value##errors;
+          switch (Js.toOption(value)) {
+          | Some(value) =>
+            Some(
+              value
+              |> Js.Array.map(value =>
+                   let field = {
+                     let value = value##field;
+                     switch (Obj.magic(value: string)) {
+                     | \\"FIRST\\" => \`FIRST
+                     | \\"SECOND\\" => \`SECOND
+                     | \\"THIRD\\" => \`THIRD
+                     | _ => raise(Not_found)
+                     };
+                   }
+                   and message = {
+                     let value = value##message;
+                     value;
+                   };
+                   {\\"message\\": message, \\"field\\": field};
+                 ),
+            )
+          | None => None
+          };
+        };
+        {\\"errors\\": errors};
+      };
+      {\\"mutationWithError\\": mutationWithError};
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let mutationWithError = {
+        let value = value##mutationWithError;
+        let errors = {
+          let value = value##errors;
+          switch (value) {
+          | Some(value) =>
+            Js.Nullable.return(
+              value
+              |> Js.Array.map(value =>
+                   let field = {
+                     let value = value##field;
+                     switch (value) {
+                     | \`FIRST => \\"FIRST\\"
+                     | \`SECOND => \\"SECOND\\"
+                     | \`THIRD => \\"THIRD\\"
+                     };
+                   }
+                   and message = {
+                     let value = value##message;
+                     value;
+                   };
+                   {\\"message\\": message, \\"field\\": field};
+                 ),
+            )
+          | None => Js.Nullable.null
+          };
+        };
+        {\\"errors\\": errors};
+      };
+      {\\"mutationWithError\\": mutationWithError};
+    };
+  let definition = (parse, query, serialize);
+};
+module ByDirective = {
+  module Raw = {
+    type t_mutationWithError_errors_field = string;
+    type t_mutationWithError_errors = {
+      .
+      \\"message\\": string,
+      \\"field\\": t_mutationWithError_errors_field,
+    };
+    type t_mutationWithError = {
+      .
+      \\"errors\\": Js.Nullable.t(array(t_mutationWithError_errors)),
+    };
+    type t = {. \\"mutationWithError\\": t_mutationWithError};
+  };
+  let query = \\"mutation   {\\\\nmutationWithError  {\\\\nerrors  {\\\\nmessage  \\\\nfield @ppxOmitFutureValue \\\\n}\\\\n\\\\n}\\\\n\\\\n}\\\\n\\";
+  type t_mutationWithError_errors_field = [ | \`FIRST | \`SECOND | \`THIRD];
+  type t_mutationWithError_errors = {
+    .
+    \\"message\\": string,
+    \\"field\\": t_mutationWithError_errors_field,
+  };
+  type t_mutationWithError = {
+    .
+    \\"errors\\": option(array(t_mutationWithError_errors)),
+  };
+  type t = {. \\"mutationWithError\\": t_mutationWithError};
+  type operation = t;
+  let parse: Raw.t => t =
+    value => {
+      let mutationWithError = {
+        let value = value##mutationWithError;
+        let errors = {
+          let value = value##errors;
+          switch (Js.toOption(value)) {
+          | Some(value) =>
+            Some(
+              value
+              |> Js.Array.map(value =>
+                   let field = {
+                     let value = value##field;
+                     switch (Obj.magic(value: string)) {
+                     | \\"FIRST\\" => \`FIRST
+                     | \\"SECOND\\" => \`SECOND
+                     | \\"THIRD\\" => \`THIRD
+                     | _ => raise(Not_found)
+                     };
+                   }
+                   and message = {
+                     let value = value##message;
+                     value;
+                   };
+                   {\\"message\\": message, \\"field\\": field};
+                 ),
+            )
+          | None => None
+          };
+        };
+        {\\"errors\\": errors};
+      };
+      {\\"mutationWithError\\": mutationWithError};
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let mutationWithError = {
+        let value = value##mutationWithError;
+        let errors = {
+          let value = value##errors;
+          switch (value) {
+          | Some(value) =>
+            Js.Nullable.return(
+              value
+              |> Js.Array.map(value =>
+                   let field = {
+                     let value = value##field;
+                     switch (value) {
+                     | \`FIRST => \\"FIRST\\"
+                     | \`SECOND => \\"SECOND\\"
+                     | \`THIRD => \\"THIRD\\"
+                     };
+                   }
+                   and message = {
+                     let value = value##message;
+                     value;
+                   };
+                   {\\"message\\": message, \\"field\\": field};
+                 ),
+            )
+          | None => Js.Nullable.null
+          };
+        };
+        {\\"errors\\": errors};
+      };
+      {\\"mutationWithError\\": mutationWithError};
+    };
+  let definition = (parse, query, serialize);
+};
+"
+`;
+
+exports[`Objects omitFutureValueUnion.re 1`] = `
+"[@ocaml.ppx.context
+  {
+    tool_name: \\"migrate_driver\\",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module Normal = {
+  module Raw = {
+    type t_dogOrHuman_Dog = {
+      .
+      \\"__typename\\": string,
+      \\"name\\": string,
+      \\"barkVolume\\": float,
+    };
+    type t_dogOrHuman_Human = {
+      .
+      \\"__typename\\": string,
+      \\"name\\": string,
+    };
+    type t_dogOrHuman;
+    type t = {. \\"dogOrHuman\\": t_dogOrHuman};
+  };
+  let query = \\"query   {\\\\ndogOrHuman  {\\\\n__typename\\\\n...on Dog   {\\\\nname  \\\\nbarkVolume  \\\\n}\\\\n\\\\n...on Human   {\\\\nname  \\\\n}\\\\n\\\\n}\\\\n\\\\n}\\\\n\\";
+  type t_dogOrHuman_Dog = {
+    .
+    \\"name\\": string,
+    \\"barkVolume\\": float,
+  };
+  type t_dogOrHuman_Human = {. \\"name\\": string};
+  type t_dogOrHuman = [
+    | \`FutureAddedValue(Js.Json.t)
+    | \`Dog(t_dogOrHuman_Dog)
+    | \`Human(t_dogOrHuman_Human)
+  ];
+  type t = {. \\"dogOrHuman\\": t_dogOrHuman};
+  type operation = t;
+  let parse: Raw.t => t =
+    value => {
+      let dogOrHuman = {
+        let value = value##dogOrHuman;
+        let typename: string =
+          Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), \\"__typename\\"));
+        (
+          switch (typename) {
+          | \\"Dog\\" =>
+            \`Dog(
+              {
+                let value: Raw.t_dogOrHuman_Dog = Obj.magic(value);
+                let barkVolume = {
+                  let value = value##barkVolume;
+                  value;
+                }
+                and name = {
+                  let value = value##name;
+                  value;
+                };
+                {\\"name\\": name, \\"barkVolume\\": barkVolume};
+              },
+            )
+          | \\"Human\\" =>
+            \`Human(
+              {
+                let value: Raw.t_dogOrHuman_Human = Obj.magic(value);
+                let name = {
+                  let value = value##name;
+                  value;
+                };
+                {\\"name\\": name};
+              },
+            )
+          | _ => \`FutureAddedValue(Obj.magic(value): Js.Json.t)
+          }: t_dogOrHuman
+        );
+      };
+      {\\"dogOrHuman\\": dogOrHuman};
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let dogOrHuman = {
+        let value = value##dogOrHuman;
+        switch (value) {
+        | \`Dog(value) => (
+            Obj.magic(
+              {
+                let barkVolume = {
+                  let value = value##barkVolume;
+                  value;
+                }
+                and name = {
+                  let value = value##name;
+                  value;
+                };
+                {\\"__typename\\": \\"Dog\\", \\"name\\": name, \\"barkVolume\\": barkVolume};
+              },
+            ): Raw.t_dogOrHuman
+          )
+        | \`Human(value) => (
+            Obj.magic(
+              {
+                let name = {
+                  let value = value##name;
+                  value;
+                };
+                {\\"__typename\\": \\"Human\\", \\"name\\": name};
+              },
+            ): Raw.t_dogOrHuman
+          )
+        | \`FutureAddedValue(value) => (Obj.magic(value): Raw.t_dogOrHuman)
+        };
+      };
+      {\\"dogOrHuman\\": dogOrHuman};
+    };
+  let definition = (parse, query, serialize);
+};
+module ByConfig = {
+  module Raw = {
+    type t_dogOrHuman_Dog = {
+      .
+      \\"__typename\\": string,
+      \\"name\\": string,
+      \\"barkVolume\\": float,
+    };
+    type t_dogOrHuman_Human = {
+      .
+      \\"__typename\\": string,
+      \\"name\\": string,
+    };
+    type t_dogOrHuman;
+    type t = {. \\"dogOrHuman\\": t_dogOrHuman};
+  };
+  let query = \\"query   {\\\\ndogOrHuman  {\\\\n__typename\\\\n...on Dog   {\\\\nname  \\\\nbarkVolume  \\\\n}\\\\n\\\\n...on Human   {\\\\nname  \\\\n}\\\\n\\\\n}\\\\n\\\\n}\\\\n\\";
+  type t_dogOrHuman_Dog = {
+    .
+    \\"name\\": string,
+    \\"barkVolume\\": float,
+  };
+  type t_dogOrHuman_Human = {. \\"name\\": string};
+  type t_dogOrHuman = [
+    | \`Dog(t_dogOrHuman_Dog)
+    | \`Human(t_dogOrHuman_Human)
+  ];
+  type t = {. \\"dogOrHuman\\": t_dogOrHuman};
+  type operation = t;
+  let parse: Raw.t => t =
+    value => {
+      let dogOrHuman = {
+        let value = value##dogOrHuman;
+        let typename: string =
+          Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), \\"__typename\\"));
+        (
+          switch (typename) {
+          | \\"Dog\\" =>
+            \`Dog(
+              {
+                let value: Raw.t_dogOrHuman_Dog = Obj.magic(value);
+                let barkVolume = {
+                  let value = value##barkVolume;
+                  value;
+                }
+                and name = {
+                  let value = value##name;
+                  value;
+                };
+                {\\"name\\": name, \\"barkVolume\\": barkVolume};
+              },
+            )
+          | \\"Human\\" =>
+            \`Human(
+              {
+                let value: Raw.t_dogOrHuman_Human = Obj.magic(value);
+                let name = {
+                  let value = value##name;
+                  value;
+                };
+                {\\"name\\": name};
+              },
+            )
+          | _ => raise(Not_found)
+          }: t_dogOrHuman
+        );
+      };
+      {\\"dogOrHuman\\": dogOrHuman};
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let dogOrHuman = {
+        let value = value##dogOrHuman;
+        switch (value) {
+        | \`Dog(value) => (
+            Obj.magic(
+              {
+                let barkVolume = {
+                  let value = value##barkVolume;
+                  value;
+                }
+                and name = {
+                  let value = value##name;
+                  value;
+                };
+                {\\"__typename\\": \\"Dog\\", \\"name\\": name, \\"barkVolume\\": barkVolume};
+              },
+            ): Raw.t_dogOrHuman
+          )
+        | \`Human(value) => (
+            Obj.magic(
+              {
+                let name = {
+                  let value = value##name;
+                  value;
+                };
+                {\\"__typename\\": \\"Human\\", \\"name\\": name};
+              },
+            ): Raw.t_dogOrHuman
+          )
+        };
+      };
+      {\\"dogOrHuman\\": dogOrHuman};
+    };
+  let definition = (parse, query, serialize);
+};
+module ByDirective = {
+  module Raw = {
+    type t_dogOrHuman_Dog = {
+      .
+      \\"__typename\\": string,
+      \\"name\\": string,
+      \\"barkVolume\\": float,
+    };
+    type t_dogOrHuman_Human = {
+      .
+      \\"__typename\\": string,
+      \\"name\\": string,
+    };
+    type t_dogOrHuman;
+    type t = {. \\"dogOrHuman\\": t_dogOrHuman};
+  };
+  let query = \\"query   {\\\\ndogOrHuman @ppxOmitFutureValue {\\\\n__typename\\\\n...on Dog   {\\\\nname  \\\\nbarkVolume  \\\\n}\\\\n\\\\n...on Human   {\\\\nname  \\\\n}\\\\n\\\\n}\\\\n\\\\n}\\\\n\\";
+  type t_dogOrHuman_Dog = {
+    .
+    \\"name\\": string,
+    \\"barkVolume\\": float,
+  };
+  type t_dogOrHuman_Human = {. \\"name\\": string};
+  type t_dogOrHuman = [
+    | \`Dog(t_dogOrHuman_Dog)
+    | \`Human(t_dogOrHuman_Human)
+  ];
+  type t = {. \\"dogOrHuman\\": t_dogOrHuman};
+  type operation = t;
+  let parse: Raw.t => t =
+    value => {
+      let dogOrHuman = {
+        let value = value##dogOrHuman;
+        let typename: string =
+          Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), \\"__typename\\"));
+        (
+          switch (typename) {
+          | \\"Dog\\" =>
+            \`Dog(
+              {
+                let value: Raw.t_dogOrHuman_Dog = Obj.magic(value);
+                let barkVolume = {
+                  let value = value##barkVolume;
+                  value;
+                }
+                and name = {
+                  let value = value##name;
+                  value;
+                };
+                {\\"name\\": name, \\"barkVolume\\": barkVolume};
+              },
+            )
+          | \\"Human\\" =>
+            \`Human(
+              {
+                let value: Raw.t_dogOrHuman_Human = Obj.magic(value);
+                let name = {
+                  let value = value##name;
+                  value;
+                };
+                {\\"name\\": name};
+              },
+            )
+          | _ => raise(Not_found)
+          }: t_dogOrHuman
+        );
+      };
+      {\\"dogOrHuman\\": dogOrHuman};
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let dogOrHuman = {
+        let value = value##dogOrHuman;
+        switch (value) {
+        | \`Dog(value) => (
+            Obj.magic(
+              {
+                let barkVolume = {
+                  let value = value##barkVolume;
+                  value;
+                }
+                and name = {
+                  let value = value##name;
+                  value;
+                };
+                {\\"__typename\\": \\"Dog\\", \\"name\\": name, \\"barkVolume\\": barkVolume};
+              },
+            ): Raw.t_dogOrHuman
+          )
+        | \`Human(value) => (
+            Obj.magic(
+              {
+                let name = {
+                  let value = value##name;
+                  value;
+                };
+                {\\"__typename\\": \\"Human\\", \\"name\\": name};
+              },
+            ): Raw.t_dogOrHuman
+          )
+        };
+      };
+      {\\"dogOrHuman\\": dogOrHuman};
+    };
+  let definition = (parse, query, serialize);
+};
+"
+`;
+
 exports[`Objects pokedexApolloMode.re 1`] = `
 "[@ocaml.ppx.context
   {
@@ -22929,6 +25137,736 @@ NonrecursiveInput {
   and makeInputObjectEmbeddedInput = (~field=?, ()): t_variables_EmbeddedInput => {
     field: field,
   };
+  let definition = (parse, query, serialize);
+};
+"
+`;
+
+exports[`Records omitFutureValueEnum.re 1`] = `
+"[@ocaml.ppx.context
+  {
+    tool_name: \\"migrate_driver\\",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module Normal = {
+  module Raw = {
+    type t_mutationWithError_errors_field = string;
+    type t_mutationWithError_errors = {
+      message: string,
+      field: t_mutationWithError_errors_field,
+    };
+    type t_mutationWithError = {
+      errors: Js.Nullable.t(array(t_mutationWithError_errors)),
+    };
+    type t = {mutationWithError: t_mutationWithError};
+  };
+  let query = \\"mutation   {\\\\nmutationWithError  {\\\\nerrors  {\\\\nmessage  \\\\nfield  \\\\n}\\\\n\\\\n}\\\\n\\\\n}\\\\n\\";
+  type t_mutationWithError_errors_field = [
+    | \`FutureAddedValue(string)
+    | \`FIRST
+    | \`SECOND
+    | \`THIRD
+  ];
+  type t_mutationWithError_errors = {
+    message: string,
+    field: t_mutationWithError_errors_field,
+  };
+  type t_mutationWithError = {
+    errors: option(array(t_mutationWithError_errors)),
+  };
+  type t = {mutationWithError: t_mutationWithError};
+  type operation = t;
+  let parse: Raw.t => t =
+    (value) => (
+      {
+        mutationWithError: {
+          let value = (value: Raw.t).mutationWithError;
+          (
+            {
+              errors: {
+                let value = (value: Raw.t_mutationWithError).errors;
+                switch (Js.toOption(value)) {
+                | Some(value) =>
+                  Some(
+                    value
+                    |> Js.Array.map((value) =>
+                         (
+                           {
+                             message: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).
+                                   message;
+                               value;
+                             },
+                             field: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).field;
+                               switch (Obj.magic(value: string)) {
+                               | \\"FIRST\\" => \`FIRST
+                               | \\"SECOND\\" => \`SECOND
+                               | \\"THIRD\\" => \`THIRD
+                               | other => \`FutureAddedValue(other)
+                               };
+                             },
+                           }: t_mutationWithError_errors
+                         )
+                       ),
+                  )
+                | None => None
+                };
+              },
+            }: t_mutationWithError
+          );
+        },
+      }: t
+    );
+  let serialize: t => Raw.t =
+    (value) => (
+      {
+        let mutationWithError = {
+          let value = (value: t).mutationWithError;
+          (
+            {
+              let errors = {
+                let value = (value: t_mutationWithError).errors;
+                switch (value) {
+                | Some(value) =>
+                  Js.Nullable.return(
+                    value
+                    |> Js.Array.map((value) =>
+                         (
+                           {
+                             let field = {
+                               let value =
+                                 (value: t_mutationWithError_errors).field;
+                               switch (value) {
+                               | \`FIRST => \\"FIRST\\"
+                               | \`SECOND => \\"SECOND\\"
+                               | \`THIRD => \\"THIRD\\"
+                               | \`FutureAddedValue(other) => other
+                               };
+                             }
+                             and message = {
+                               let value =
+                                 (value: t_mutationWithError_errors).message;
+                               value;
+                             };
+                             {message, field};
+                           }: Raw.t_mutationWithError_errors
+                         )
+                       ),
+                  )
+                | None => Js.Nullable.null
+                };
+              };
+              {errors: errors};
+            }: Raw.t_mutationWithError
+          );
+        };
+        {mutationWithError: mutationWithError};
+      }: Raw.t
+    );
+  let definition = (parse, query, serialize);
+};
+module ByConfig = {
+  module Raw = {
+    type t_mutationWithError_errors_field = string;
+    type t_mutationWithError_errors = {
+      message: string,
+      field: t_mutationWithError_errors_field,
+    };
+    type t_mutationWithError = {
+      errors: Js.Nullable.t(array(t_mutationWithError_errors)),
+    };
+    type t = {mutationWithError: t_mutationWithError};
+  };
+  let query = \\"mutation   {\\\\nmutationWithError  {\\\\nerrors  {\\\\nmessage  \\\\nfield  \\\\n}\\\\n\\\\n}\\\\n\\\\n}\\\\n\\";
+  type t_mutationWithError_errors_field = [ | \`FIRST | \`SECOND | \`THIRD];
+  type t_mutationWithError_errors = {
+    message: string,
+    field: t_mutationWithError_errors_field,
+  };
+  type t_mutationWithError = {
+    errors: option(array(t_mutationWithError_errors)),
+  };
+  type t = {mutationWithError: t_mutationWithError};
+  type operation = t;
+  let parse: Raw.t => t =
+    (value) => (
+      {
+        mutationWithError: {
+          let value = (value: Raw.t).mutationWithError;
+          (
+            {
+              errors: {
+                let value = (value: Raw.t_mutationWithError).errors;
+                switch (Js.toOption(value)) {
+                | Some(value) =>
+                  Some(
+                    value
+                    |> Js.Array.map((value) =>
+                         (
+                           {
+                             message: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).
+                                   message;
+                               value;
+                             },
+                             field: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).field;
+                               switch (Obj.magic(value: string)) {
+                               | \\"FIRST\\" => \`FIRST
+                               | \\"SECOND\\" => \`SECOND
+                               | \\"THIRD\\" => \`THIRD
+                               | _ => raise(Not_found)
+                               };
+                             },
+                           }: t_mutationWithError_errors
+                         )
+                       ),
+                  )
+                | None => None
+                };
+              },
+            }: t_mutationWithError
+          );
+        },
+      }: t
+    );
+  let serialize: t => Raw.t =
+    (value) => (
+      {
+        let mutationWithError = {
+          let value = (value: t).mutationWithError;
+          (
+            {
+              let errors = {
+                let value = (value: t_mutationWithError).errors;
+                switch (value) {
+                | Some(value) =>
+                  Js.Nullable.return(
+                    value
+                    |> Js.Array.map((value) =>
+                         (
+                           {
+                             let field = {
+                               let value =
+                                 (value: t_mutationWithError_errors).field;
+                               switch (value) {
+                               | \`FIRST => \\"FIRST\\"
+                               | \`SECOND => \\"SECOND\\"
+                               | \`THIRD => \\"THIRD\\"
+                               };
+                             }
+                             and message = {
+                               let value =
+                                 (value: t_mutationWithError_errors).message;
+                               value;
+                             };
+                             {message, field};
+                           }: Raw.t_mutationWithError_errors
+                         )
+                       ),
+                  )
+                | None => Js.Nullable.null
+                };
+              };
+              {errors: errors};
+            }: Raw.t_mutationWithError
+          );
+        };
+        {mutationWithError: mutationWithError};
+      }: Raw.t
+    );
+  let definition = (parse, query, serialize);
+};
+module ByDirective = {
+  module Raw = {
+    type t_mutationWithError_errors_field = string;
+    type t_mutationWithError_errors = {
+      message: string,
+      field: t_mutationWithError_errors_field,
+    };
+    type t_mutationWithError = {
+      errors: Js.Nullable.t(array(t_mutationWithError_errors)),
+    };
+    type t = {mutationWithError: t_mutationWithError};
+  };
+  let query = \\"mutation   {\\\\nmutationWithError  {\\\\nerrors  {\\\\nmessage  \\\\nfield @ppxOmitFutureValue \\\\n}\\\\n\\\\n}\\\\n\\\\n}\\\\n\\";
+  type t_mutationWithError_errors_field = [ | \`FIRST | \`SECOND | \`THIRD];
+  type t_mutationWithError_errors = {
+    message: string,
+    field: t_mutationWithError_errors_field,
+  };
+  type t_mutationWithError = {
+    errors: option(array(t_mutationWithError_errors)),
+  };
+  type t = {mutationWithError: t_mutationWithError};
+  type operation = t;
+  let parse: Raw.t => t =
+    (value) => (
+      {
+        mutationWithError: {
+          let value = (value: Raw.t).mutationWithError;
+          (
+            {
+              errors: {
+                let value = (value: Raw.t_mutationWithError).errors;
+                switch (Js.toOption(value)) {
+                | Some(value) =>
+                  Some(
+                    value
+                    |> Js.Array.map((value) =>
+                         (
+                           {
+                             message: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).
+                                   message;
+                               value;
+                             },
+                             field: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).field;
+                               switch (Obj.magic(value: string)) {
+                               | \\"FIRST\\" => \`FIRST
+                               | \\"SECOND\\" => \`SECOND
+                               | \\"THIRD\\" => \`THIRD
+                               | _ => raise(Not_found)
+                               };
+                             },
+                           }: t_mutationWithError_errors
+                         )
+                       ),
+                  )
+                | None => None
+                };
+              },
+            }: t_mutationWithError
+          );
+        },
+      }: t
+    );
+  let serialize: t => Raw.t =
+    (value) => (
+      {
+        let mutationWithError = {
+          let value = (value: t).mutationWithError;
+          (
+            {
+              let errors = {
+                let value = (value: t_mutationWithError).errors;
+                switch (value) {
+                | Some(value) =>
+                  Js.Nullable.return(
+                    value
+                    |> Js.Array.map((value) =>
+                         (
+                           {
+                             let field = {
+                               let value =
+                                 (value: t_mutationWithError_errors).field;
+                               switch (value) {
+                               | \`FIRST => \\"FIRST\\"
+                               | \`SECOND => \\"SECOND\\"
+                               | \`THIRD => \\"THIRD\\"
+                               };
+                             }
+                             and message = {
+                               let value =
+                                 (value: t_mutationWithError_errors).message;
+                               value;
+                             };
+                             {message, field};
+                           }: Raw.t_mutationWithError_errors
+                         )
+                       ),
+                  )
+                | None => Js.Nullable.null
+                };
+              };
+              {errors: errors};
+            }: Raw.t_mutationWithError
+          );
+        };
+        {mutationWithError: mutationWithError};
+      }: Raw.t
+    );
+  let definition = (parse, query, serialize);
+};
+"
+`;
+
+exports[`Records omitFutureValueUnion.re 1`] = `
+"[@ocaml.ppx.context
+  {
+    tool_name: \\"migrate_driver\\",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module Normal = {
+  module Raw = {
+    type t_dogOrHuman_Dog = {
+      __typename: string,
+      name: string,
+      barkVolume: float,
+    };
+    type t_dogOrHuman_Human = {
+      __typename: string,
+      name: string,
+    };
+    type t_dogOrHuman;
+    type t = {dogOrHuman: t_dogOrHuman};
+  };
+  let query = \\"query   {\\\\ndogOrHuman  {\\\\n__typename\\\\n...on Dog   {\\\\nname  \\\\nbarkVolume  \\\\n}\\\\n\\\\n...on Human   {\\\\nname  \\\\n}\\\\n\\\\n}\\\\n\\\\n}\\\\n\\";
+  type t_dogOrHuman_Dog = {
+    name: string,
+    barkVolume: float,
+  };
+  type t_dogOrHuman_Human = {name: string};
+  type t_dogOrHuman = [
+    | \`FutureAddedValue(Js.Json.t)
+    | \`Dog(t_dogOrHuman_Dog)
+    | \`Human(t_dogOrHuman_Human)
+  ];
+  type t = {dogOrHuman: t_dogOrHuman};
+  type operation = t;
+  let parse: Raw.t => t =
+    (value) => (
+      {
+        dogOrHuman: {
+          let value = (value: Raw.t).dogOrHuman;
+          let typename: string =
+            Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), \\"__typename\\"));
+          (
+            switch (typename) {
+            | \\"Dog\\" =>
+              \`Dog(
+                {
+                  let value: Raw.t_dogOrHuman_Dog = Obj.magic(value);
+                  (
+                    {
+                      name: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).name;
+                        value;
+                      },
+                      barkVolume: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).barkVolume;
+                        value;
+                      },
+                    }: t_dogOrHuman_Dog
+                  );
+                },
+              )
+            | \\"Human\\" =>
+              \`Human(
+                {
+                  let value: Raw.t_dogOrHuman_Human = Obj.magic(value);
+                  (
+                    {
+                      name: {
+                        let value = (value: Raw.t_dogOrHuman_Human).name;
+                        value;
+                      },
+                    }: t_dogOrHuman_Human
+                  );
+                },
+              )
+            | _ => \`FutureAddedValue(Obj.magic(value): Js.Json.t)
+            }: t_dogOrHuman
+          );
+        },
+      }: t
+    );
+  let serialize: t => Raw.t =
+    (value) => (
+      {
+        let dogOrHuman = {
+          let value = (value: t).dogOrHuman;
+          switch (value) {
+          | \`Dog(value) => (
+              Obj.magic(
+                {
+                  let barkVolume = {
+                    let value = (value: t_dogOrHuman_Dog).barkVolume;
+                    value;
+                  }
+                  and name = {
+                    let value = (value: t_dogOrHuman_Dog).name;
+                    value;
+                  };
+                  {__typename: \\"Dog\\", name, barkVolume};
+                }: Raw.t_dogOrHuman_Dog,
+              ): Raw.t_dogOrHuman
+            )
+          | \`Human(value) => (
+              Obj.magic(
+                {
+                  let name = {
+                    let value = (value: t_dogOrHuman_Human).name;
+                    value;
+                  };
+                  {__typename: \\"Human\\", name};
+                }: Raw.t_dogOrHuman_Human,
+              ): Raw.t_dogOrHuman
+            )
+          | \`FutureAddedValue(value) => (Obj.magic(value): Raw.t_dogOrHuman)
+          };
+        };
+        {dogOrHuman: dogOrHuman};
+      }: Raw.t
+    );
+  let definition = (parse, query, serialize);
+};
+module ByConfig = {
+  module Raw = {
+    type t_dogOrHuman_Dog = {
+      __typename: string,
+      name: string,
+      barkVolume: float,
+    };
+    type t_dogOrHuman_Human = {
+      __typename: string,
+      name: string,
+    };
+    type t_dogOrHuman;
+    type t = {dogOrHuman: t_dogOrHuman};
+  };
+  let query = \\"query   {\\\\ndogOrHuman  {\\\\n__typename\\\\n...on Dog   {\\\\nname  \\\\nbarkVolume  \\\\n}\\\\n\\\\n...on Human   {\\\\nname  \\\\n}\\\\n\\\\n}\\\\n\\\\n}\\\\n\\";
+  type t_dogOrHuman_Dog = {
+    name: string,
+    barkVolume: float,
+  };
+  type t_dogOrHuman_Human = {name: string};
+  type t_dogOrHuman = [
+    | \`Dog(t_dogOrHuman_Dog)
+    | \`Human(t_dogOrHuman_Human)
+  ];
+  type t = {dogOrHuman: t_dogOrHuman};
+  type operation = t;
+  let parse: Raw.t => t =
+    (value) => (
+      {
+        dogOrHuman: {
+          let value = (value: Raw.t).dogOrHuman;
+          let typename: string =
+            Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), \\"__typename\\"));
+          (
+            switch (typename) {
+            | \\"Dog\\" =>
+              \`Dog(
+                {
+                  let value: Raw.t_dogOrHuman_Dog = Obj.magic(value);
+                  (
+                    {
+                      name: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).name;
+                        value;
+                      },
+                      barkVolume: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).barkVolume;
+                        value;
+                      },
+                    }: t_dogOrHuman_Dog
+                  );
+                },
+              )
+            | \\"Human\\" =>
+              \`Human(
+                {
+                  let value: Raw.t_dogOrHuman_Human = Obj.magic(value);
+                  (
+                    {
+                      name: {
+                        let value = (value: Raw.t_dogOrHuman_Human).name;
+                        value;
+                      },
+                    }: t_dogOrHuman_Human
+                  );
+                },
+              )
+            | _ => raise(Not_found)
+            }: t_dogOrHuman
+          );
+        },
+      }: t
+    );
+  let serialize: t => Raw.t =
+    (value) => (
+      {
+        let dogOrHuman = {
+          let value = (value: t).dogOrHuman;
+          switch (value) {
+          | \`Dog(value) => (
+              Obj.magic(
+                {
+                  let barkVolume = {
+                    let value = (value: t_dogOrHuman_Dog).barkVolume;
+                    value;
+                  }
+                  and name = {
+                    let value = (value: t_dogOrHuman_Dog).name;
+                    value;
+                  };
+                  {__typename: \\"Dog\\", name, barkVolume};
+                }: Raw.t_dogOrHuman_Dog,
+              ): Raw.t_dogOrHuman
+            )
+          | \`Human(value) => (
+              Obj.magic(
+                {
+                  let name = {
+                    let value = (value: t_dogOrHuman_Human).name;
+                    value;
+                  };
+                  {__typename: \\"Human\\", name};
+                }: Raw.t_dogOrHuman_Human,
+              ): Raw.t_dogOrHuman
+            )
+          };
+        };
+        {dogOrHuman: dogOrHuman};
+      }: Raw.t
+    );
+  let definition = (parse, query, serialize);
+};
+module ByDirective = {
+  module Raw = {
+    type t_dogOrHuman_Dog = {
+      __typename: string,
+      name: string,
+      barkVolume: float,
+    };
+    type t_dogOrHuman_Human = {
+      __typename: string,
+      name: string,
+    };
+    type t_dogOrHuman;
+    type t = {dogOrHuman: t_dogOrHuman};
+  };
+  let query = \\"query   {\\\\ndogOrHuman @ppxOmitFutureValue {\\\\n__typename\\\\n...on Dog   {\\\\nname  \\\\nbarkVolume  \\\\n}\\\\n\\\\n...on Human   {\\\\nname  \\\\n}\\\\n\\\\n}\\\\n\\\\n}\\\\n\\";
+  type t_dogOrHuman_Dog = {
+    name: string,
+    barkVolume: float,
+  };
+  type t_dogOrHuman_Human = {name: string};
+  type t_dogOrHuman = [
+    | \`Dog(t_dogOrHuman_Dog)
+    | \`Human(t_dogOrHuman_Human)
+  ];
+  type t = {dogOrHuman: t_dogOrHuman};
+  type operation = t;
+  let parse: Raw.t => t =
+    (value) => (
+      {
+        dogOrHuman: {
+          let value = (value: Raw.t).dogOrHuman;
+          let typename: string =
+            Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), \\"__typename\\"));
+          (
+            switch (typename) {
+            | \\"Dog\\" =>
+              \`Dog(
+                {
+                  let value: Raw.t_dogOrHuman_Dog = Obj.magic(value);
+                  (
+                    {
+                      name: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).name;
+                        value;
+                      },
+                      barkVolume: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).barkVolume;
+                        value;
+                      },
+                    }: t_dogOrHuman_Dog
+                  );
+                },
+              )
+            | \\"Human\\" =>
+              \`Human(
+                {
+                  let value: Raw.t_dogOrHuman_Human = Obj.magic(value);
+                  (
+                    {
+                      name: {
+                        let value = (value: Raw.t_dogOrHuman_Human).name;
+                        value;
+                      },
+                    }: t_dogOrHuman_Human
+                  );
+                },
+              )
+            | _ => raise(Not_found)
+            }: t_dogOrHuman
+          );
+        },
+      }: t
+    );
+  let serialize: t => Raw.t =
+    (value) => (
+      {
+        let dogOrHuman = {
+          let value = (value: t).dogOrHuman;
+          switch (value) {
+          | \`Dog(value) => (
+              Obj.magic(
+                {
+                  let barkVolume = {
+                    let value = (value: t_dogOrHuman_Dog).barkVolume;
+                    value;
+                  }
+                  and name = {
+                    let value = (value: t_dogOrHuman_Dog).name;
+                    value;
+                  };
+                  {__typename: \\"Dog\\", name, barkVolume};
+                }: Raw.t_dogOrHuman_Dog,
+              ): Raw.t_dogOrHuman
+            )
+          | \`Human(value) => (
+              Obj.magic(
+                {
+                  let name = {
+                    let value = (value: t_dogOrHuman_Human).name;
+                    value;
+                  };
+                  {__typename: \\"Human\\", name};
+                }: Raw.t_dogOrHuman_Human,
+              ): Raw.t_dogOrHuman
+            )
+          };
+        };
+        {dogOrHuman: dogOrHuman};
+      }: Raw.t
+    );
   let definition = (parse, query, serialize);
 };
 "

--- a/tests_bucklescript/operations/omitFutureValueEnum.re
+++ b/tests_bucklescript/operations/omitFutureValueEnum.re
@@ -1,0 +1,46 @@
+/**
+ * Normal
+ */
+module Normal = [%graphql
+  {|
+    mutation {
+        mutationWithError {
+            errors {
+                message
+                field
+            }
+        }
+    }
+|}
+];
+/**
+ * By config
+ */
+module ByConfig = [%graphql
+  {|
+    mutation {
+        mutationWithError {
+            errors {
+                message
+                field
+            }
+        }
+    }
+|};
+  {future_added_value: false}
+];
+/**
+ * By directive
+ */
+module ByDirective = [%graphql
+  {|
+    mutation {
+        mutationWithError {
+            errors {
+                message
+                field @ppxOmitFutureValue
+            }
+        }
+    }
+|}
+];

--- a/tests_bucklescript/operations/omitFutureValueUnion.re
+++ b/tests_bucklescript/operations/omitFutureValueUnion.re
@@ -1,0 +1,58 @@
+/**
+ * Normal
+ */
+module Normal = [%graphql
+  {|
+    {
+    dogOrHuman {
+      ...on Dog {
+        name
+        barkVolume
+      }
+
+      ...on Human {
+        name
+      }
+    }
+  }
+|}
+];
+/**
+ * By config
+ */
+module ByConfig = [%graphql
+  {|
+    {
+    dogOrHuman {
+      ...on Dog {
+        name
+        barkVolume
+      }
+
+      ...on Human {
+        name
+      }
+    }
+  }
+|};
+  {future_added_value: false}
+];
+/**
+ * By directive
+ */
+module ByDirective = [%graphql
+  {|
+    {
+    dogOrHuman @ppxOmitFutureValue {
+      ...on Dog {
+        name
+        barkVolume
+      }
+
+      ...on Human {
+        name
+      }
+    }
+  }
+|}
+];

--- a/tests_bucklescript/static_snapshots/apollo-mode/operations/omitFutureValueEnum.re
+++ b/tests_bucklescript/static_snapshots/apollo-mode/operations/omitFutureValueEnum.re
@@ -1,0 +1,438 @@
+[@ocaml.ppx.context
+  {
+    tool_name: "migrate_driver",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module Normal = {
+  module Raw = {
+    type t_mutationWithError_errors_field = string;
+    type t_mutationWithError_errors = {
+      __typename: string,
+      message: string,
+      field: t_mutationWithError_errors_field,
+    };
+    type t_mutationWithError = {
+      __typename: string,
+      errors: Js.Nullable.t(array(t_mutationWithError_errors)),
+    };
+    type t = {mutationWithError: t_mutationWithError};
+  };
+  let query = "mutation   {\nmutationWithError  {\n__typename  \nerrors  {\n__typename  \nmessage  \nfield  \n}\n\n}\n\n}\n";
+  type t_mutationWithError_errors_field = [
+    | `FutureAddedValue(string)
+    | `FIRST
+    | `SECOND
+    | `THIRD
+  ];
+  type t_mutationWithError_errors = {
+    __typename: string,
+    message: string,
+    field: t_mutationWithError_errors_field,
+  };
+  type t_mutationWithError = {
+    __typename: string,
+    errors: option(array(t_mutationWithError_errors)),
+  };
+  type t = {mutationWithError: t_mutationWithError};
+  type operation = t;
+  let parse: Raw.t => t =
+    (value) => (
+      {
+        mutationWithError: {
+          let value = (value: Raw.t).mutationWithError;
+          (
+            {
+              __typename: {
+                let value = (value: Raw.t_mutationWithError).__typename;
+                value;
+              },
+              errors: {
+                let value = (value: Raw.t_mutationWithError).errors;
+                switch (Js.toOption(value)) {
+                | Some(value) =>
+                  Some(
+                    value
+                    |> Js.Array.map((value) =>
+                         (
+                           {
+                             __typename: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).
+                                   __typename;
+                               value;
+                             },
+                             message: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).
+                                   message;
+                               value;
+                             },
+                             field: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).field;
+                               switch (Obj.magic(value: string)) {
+                               | "FIRST" => `FIRST
+                               | "SECOND" => `SECOND
+                               | "THIRD" => `THIRD
+                               | other => `FutureAddedValue(other)
+                               };
+                             },
+                           }: t_mutationWithError_errors
+                         )
+                       ),
+                  )
+                | None => None
+                };
+              },
+            }: t_mutationWithError
+          );
+        },
+      }: t
+    );
+  let serialize: t => Raw.t =
+    (value) => (
+      {
+        let mutationWithError = {
+          let value = (value: t).mutationWithError;
+          (
+            {
+              let errors = {
+                let value = (value: t_mutationWithError).errors;
+                switch (value) {
+                | Some(value) =>
+                  Js.Nullable.return(
+                    value
+                    |> Js.Array.map((value) =>
+                         (
+                           {
+                             let field = {
+                               let value =
+                                 (value: t_mutationWithError_errors).field;
+                               switch (value) {
+                               | `FIRST => "FIRST"
+                               | `SECOND => "SECOND"
+                               | `THIRD => "THIRD"
+                               | `FutureAddedValue(other) => other
+                               };
+                             }
+                             and message = {
+                               let value =
+                                 (value: t_mutationWithError_errors).message;
+                               value;
+                             }
+                             and __typename = {
+                               let value =
+                                 (value: t_mutationWithError_errors).
+                                   __typename;
+                               value;
+                             };
+                             {__typename, message, field};
+                           }: Raw.t_mutationWithError_errors
+                         )
+                       ),
+                  )
+                | None => Js.Nullable.null
+                };
+              }
+              and __typename = {
+                let value = (value: t_mutationWithError).__typename;
+                value;
+              };
+              {__typename, errors};
+            }: Raw.t_mutationWithError
+          );
+        };
+        {mutationWithError: mutationWithError};
+      }: Raw.t
+    );
+  let definition = (parse, query, serialize);
+};
+module ByConfig = {
+  module Raw = {
+    type t_mutationWithError_errors_field = string;
+    type t_mutationWithError_errors = {
+      __typename: string,
+      message: string,
+      field: t_mutationWithError_errors_field,
+    };
+    type t_mutationWithError = {
+      __typename: string,
+      errors: Js.Nullable.t(array(t_mutationWithError_errors)),
+    };
+    type t = {mutationWithError: t_mutationWithError};
+  };
+  let query = "mutation   {\nmutationWithError  {\n__typename  \nerrors  {\n__typename  \nmessage  \nfield  \n}\n\n}\n\n}\n";
+  type t_mutationWithError_errors_field = [ | `FIRST | `SECOND | `THIRD];
+  type t_mutationWithError_errors = {
+    __typename: string,
+    message: string,
+    field: t_mutationWithError_errors_field,
+  };
+  type t_mutationWithError = {
+    __typename: string,
+    errors: option(array(t_mutationWithError_errors)),
+  };
+  type t = {mutationWithError: t_mutationWithError};
+  type operation = t;
+  let parse: Raw.t => t =
+    (value) => (
+      {
+        mutationWithError: {
+          let value = (value: Raw.t).mutationWithError;
+          (
+            {
+              __typename: {
+                let value = (value: Raw.t_mutationWithError).__typename;
+                value;
+              },
+              errors: {
+                let value = (value: Raw.t_mutationWithError).errors;
+                switch (Js.toOption(value)) {
+                | Some(value) =>
+                  Some(
+                    value
+                    |> Js.Array.map((value) =>
+                         (
+                           {
+                             __typename: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).
+                                   __typename;
+                               value;
+                             },
+                             message: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).
+                                   message;
+                               value;
+                             },
+                             field: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).field;
+                               switch (Obj.magic(value: string)) {
+                               | "FIRST" => `FIRST
+                               | "SECOND" => `SECOND
+                               | "THIRD" => `THIRD
+                               | _ => raise(Not_found)
+                               };
+                             },
+                           }: t_mutationWithError_errors
+                         )
+                       ),
+                  )
+                | None => None
+                };
+              },
+            }: t_mutationWithError
+          );
+        },
+      }: t
+    );
+  let serialize: t => Raw.t =
+    (value) => (
+      {
+        let mutationWithError = {
+          let value = (value: t).mutationWithError;
+          (
+            {
+              let errors = {
+                let value = (value: t_mutationWithError).errors;
+                switch (value) {
+                | Some(value) =>
+                  Js.Nullable.return(
+                    value
+                    |> Js.Array.map((value) =>
+                         (
+                           {
+                             let field = {
+                               let value =
+                                 (value: t_mutationWithError_errors).field;
+                               switch (value) {
+                               | `FIRST => "FIRST"
+                               | `SECOND => "SECOND"
+                               | `THIRD => "THIRD"
+                               };
+                             }
+                             and message = {
+                               let value =
+                                 (value: t_mutationWithError_errors).message;
+                               value;
+                             }
+                             and __typename = {
+                               let value =
+                                 (value: t_mutationWithError_errors).
+                                   __typename;
+                               value;
+                             };
+                             {__typename, message, field};
+                           }: Raw.t_mutationWithError_errors
+                         )
+                       ),
+                  )
+                | None => Js.Nullable.null
+                };
+              }
+              and __typename = {
+                let value = (value: t_mutationWithError).__typename;
+                value;
+              };
+              {__typename, errors};
+            }: Raw.t_mutationWithError
+          );
+        };
+        {mutationWithError: mutationWithError};
+      }: Raw.t
+    );
+  let definition = (parse, query, serialize);
+};
+module ByDirective = {
+  module Raw = {
+    type t_mutationWithError_errors_field = string;
+    type t_mutationWithError_errors = {
+      __typename: string,
+      message: string,
+      field: t_mutationWithError_errors_field,
+    };
+    type t_mutationWithError = {
+      __typename: string,
+      errors: Js.Nullable.t(array(t_mutationWithError_errors)),
+    };
+    type t = {mutationWithError: t_mutationWithError};
+  };
+  let query = "mutation   {\nmutationWithError  {\n__typename  \nerrors  {\n__typename  \nmessage  \nfield @ppxOmitFutureValue \n}\n\n}\n\n}\n";
+  type t_mutationWithError_errors_field = [ | `FIRST | `SECOND | `THIRD];
+  type t_mutationWithError_errors = {
+    __typename: string,
+    message: string,
+    field: t_mutationWithError_errors_field,
+  };
+  type t_mutationWithError = {
+    __typename: string,
+    errors: option(array(t_mutationWithError_errors)),
+  };
+  type t = {mutationWithError: t_mutationWithError};
+  type operation = t;
+  let parse: Raw.t => t =
+    (value) => (
+      {
+        mutationWithError: {
+          let value = (value: Raw.t).mutationWithError;
+          (
+            {
+              __typename: {
+                let value = (value: Raw.t_mutationWithError).__typename;
+                value;
+              },
+              errors: {
+                let value = (value: Raw.t_mutationWithError).errors;
+                switch (Js.toOption(value)) {
+                | Some(value) =>
+                  Some(
+                    value
+                    |> Js.Array.map((value) =>
+                         (
+                           {
+                             __typename: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).
+                                   __typename;
+                               value;
+                             },
+                             message: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).
+                                   message;
+                               value;
+                             },
+                             field: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).field;
+                               switch (Obj.magic(value: string)) {
+                               | "FIRST" => `FIRST
+                               | "SECOND" => `SECOND
+                               | "THIRD" => `THIRD
+                               | _ => raise(Not_found)
+                               };
+                             },
+                           }: t_mutationWithError_errors
+                         )
+                       ),
+                  )
+                | None => None
+                };
+              },
+            }: t_mutationWithError
+          );
+        },
+      }: t
+    );
+  let serialize: t => Raw.t =
+    (value) => (
+      {
+        let mutationWithError = {
+          let value = (value: t).mutationWithError;
+          (
+            {
+              let errors = {
+                let value = (value: t_mutationWithError).errors;
+                switch (value) {
+                | Some(value) =>
+                  Js.Nullable.return(
+                    value
+                    |> Js.Array.map((value) =>
+                         (
+                           {
+                             let field = {
+                               let value =
+                                 (value: t_mutationWithError_errors).field;
+                               switch (value) {
+                               | `FIRST => "FIRST"
+                               | `SECOND => "SECOND"
+                               | `THIRD => "THIRD"
+                               };
+                             }
+                             and message = {
+                               let value =
+                                 (value: t_mutationWithError_errors).message;
+                               value;
+                             }
+                             and __typename = {
+                               let value =
+                                 (value: t_mutationWithError_errors).
+                                   __typename;
+                               value;
+                             };
+                             {__typename, message, field};
+                           }: Raw.t_mutationWithError_errors
+                         )
+                       ),
+                  )
+                | None => Js.Nullable.null
+                };
+              }
+              and __typename = {
+                let value = (value: t_mutationWithError).__typename;
+                value;
+              };
+              {__typename, errors};
+            }: Raw.t_mutationWithError
+          );
+        };
+        {mutationWithError: mutationWithError};
+      }: Raw.t
+    );
+  let definition = (parse, query, serialize);
+};

--- a/tests_bucklescript/static_snapshots/apollo-mode/operations/omitFutureValueUnion.re
+++ b/tests_bucklescript/static_snapshots/apollo-mode/operations/omitFutureValueUnion.re
@@ -1,0 +1,416 @@
+[@ocaml.ppx.context
+  {
+    tool_name: "migrate_driver",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module Normal = {
+  module Raw = {
+    type t_dogOrHuman_Dog = {
+      __typename: string,
+      name: string,
+      barkVolume: float,
+    };
+    type t_dogOrHuman_Human = {
+      __typename: string,
+      name: string,
+    };
+    type t_dogOrHuman;
+    type t = {dogOrHuman: t_dogOrHuman};
+  };
+  let query = "query   {\ndogOrHuman  {\n__typename\n...on Dog   {\n__typename  \nname  \nbarkVolume  \n}\n\n...on Human   {\n__typename  \nname  \n}\n\n}\n\n}\n";
+  type t_dogOrHuman_Dog = {
+    __typename: string,
+    name: string,
+    barkVolume: float,
+  };
+  type t_dogOrHuman_Human = {
+    __typename: string,
+    name: string,
+  };
+  type t_dogOrHuman = [
+    | `FutureAddedValue(Js.Json.t)
+    | `Dog(t_dogOrHuman_Dog)
+    | `Human(t_dogOrHuman_Human)
+  ];
+  type t = {dogOrHuman: t_dogOrHuman};
+  type operation = t;
+  let parse: Raw.t => t =
+    (value) => (
+      {
+        dogOrHuman: {
+          let value = (value: Raw.t).dogOrHuman;
+          let typename: string =
+            Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "__typename"));
+          (
+            switch (typename) {
+            | "Dog" =>
+              `Dog(
+                {
+                  let value: Raw.t_dogOrHuman_Dog = Obj.magic(value);
+                  (
+                    {
+                      __typename: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).__typename;
+                        value;
+                      },
+                      name: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).name;
+                        value;
+                      },
+                      barkVolume: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).barkVolume;
+                        value;
+                      },
+                    }: t_dogOrHuman_Dog
+                  );
+                },
+              )
+            | "Human" =>
+              `Human(
+                {
+                  let value: Raw.t_dogOrHuman_Human = Obj.magic(value);
+                  (
+                    {
+                      __typename: {
+                        let value = (value: Raw.t_dogOrHuman_Human).__typename;
+                        value;
+                      },
+                      name: {
+                        let value = (value: Raw.t_dogOrHuman_Human).name;
+                        value;
+                      },
+                    }: t_dogOrHuman_Human
+                  );
+                },
+              )
+            | _ => `FutureAddedValue(Obj.magic(value): Js.Json.t)
+            }: t_dogOrHuman
+          );
+        },
+      }: t
+    );
+  let serialize: t => Raw.t =
+    (value) => (
+      {
+        let dogOrHuman = {
+          let value = (value: t).dogOrHuman;
+          switch (value) {
+          | `Dog(value) => (
+              Obj.magic(
+                {
+                  let barkVolume = {
+                    let value = (value: t_dogOrHuman_Dog).barkVolume;
+                    value;
+                  }
+                  and name = {
+                    let value = (value: t_dogOrHuman_Dog).name;
+                    value;
+                  }
+                  and __typename = {
+                    let value = (value: t_dogOrHuman_Dog).__typename;
+                    value;
+                  };
+                  {__typename: "Dog", name, barkVolume};
+                }: Raw.t_dogOrHuman_Dog,
+              ): Raw.t_dogOrHuman
+            )
+          | `Human(value) => (
+              Obj.magic(
+                {
+                  let name = {
+                    let value = (value: t_dogOrHuman_Human).name;
+                    value;
+                  }
+                  and __typename = {
+                    let value = (value: t_dogOrHuman_Human).__typename;
+                    value;
+                  };
+                  {__typename: "Human", name};
+                }: Raw.t_dogOrHuman_Human,
+              ): Raw.t_dogOrHuman
+            )
+          | `FutureAddedValue(value) => (Obj.magic(value): Raw.t_dogOrHuman)
+          };
+        };
+        {dogOrHuman: dogOrHuman};
+      }: Raw.t
+    );
+  let definition = (parse, query, serialize);
+};
+module ByConfig = {
+  module Raw = {
+    type t_dogOrHuman_Dog = {
+      __typename: string,
+      name: string,
+      barkVolume: float,
+    };
+    type t_dogOrHuman_Human = {
+      __typename: string,
+      name: string,
+    };
+    type t_dogOrHuman;
+    type t = {dogOrHuman: t_dogOrHuman};
+  };
+  let query = "query   {\ndogOrHuman  {\n__typename\n...on Dog   {\n__typename  \nname  \nbarkVolume  \n}\n\n...on Human   {\n__typename  \nname  \n}\n\n}\n\n}\n";
+  type t_dogOrHuman_Dog = {
+    __typename: string,
+    name: string,
+    barkVolume: float,
+  };
+  type t_dogOrHuman_Human = {
+    __typename: string,
+    name: string,
+  };
+  type t_dogOrHuman = [
+    | `Dog(t_dogOrHuman_Dog)
+    | `Human(t_dogOrHuman_Human)
+  ];
+  type t = {dogOrHuman: t_dogOrHuman};
+  type operation = t;
+  let parse: Raw.t => t =
+    (value) => (
+      {
+        dogOrHuman: {
+          let value = (value: Raw.t).dogOrHuman;
+          let typename: string =
+            Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "__typename"));
+          (
+            switch (typename) {
+            | "Dog" =>
+              `Dog(
+                {
+                  let value: Raw.t_dogOrHuman_Dog = Obj.magic(value);
+                  (
+                    {
+                      __typename: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).__typename;
+                        value;
+                      },
+                      name: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).name;
+                        value;
+                      },
+                      barkVolume: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).barkVolume;
+                        value;
+                      },
+                    }: t_dogOrHuman_Dog
+                  );
+                },
+              )
+            | "Human" =>
+              `Human(
+                {
+                  let value: Raw.t_dogOrHuman_Human = Obj.magic(value);
+                  (
+                    {
+                      __typename: {
+                        let value = (value: Raw.t_dogOrHuman_Human).__typename;
+                        value;
+                      },
+                      name: {
+                        let value = (value: Raw.t_dogOrHuman_Human).name;
+                        value;
+                      },
+                    }: t_dogOrHuman_Human
+                  );
+                },
+              )
+            | _ => raise(Not_found)
+            }: t_dogOrHuman
+          );
+        },
+      }: t
+    );
+  let serialize: t => Raw.t =
+    (value) => (
+      {
+        let dogOrHuman = {
+          let value = (value: t).dogOrHuman;
+          switch (value) {
+          | `Dog(value) => (
+              Obj.magic(
+                {
+                  let barkVolume = {
+                    let value = (value: t_dogOrHuman_Dog).barkVolume;
+                    value;
+                  }
+                  and name = {
+                    let value = (value: t_dogOrHuman_Dog).name;
+                    value;
+                  }
+                  and __typename = {
+                    let value = (value: t_dogOrHuman_Dog).__typename;
+                    value;
+                  };
+                  {__typename: "Dog", name, barkVolume};
+                }: Raw.t_dogOrHuman_Dog,
+              ): Raw.t_dogOrHuman
+            )
+          | `Human(value) => (
+              Obj.magic(
+                {
+                  let name = {
+                    let value = (value: t_dogOrHuman_Human).name;
+                    value;
+                  }
+                  and __typename = {
+                    let value = (value: t_dogOrHuman_Human).__typename;
+                    value;
+                  };
+                  {__typename: "Human", name};
+                }: Raw.t_dogOrHuman_Human,
+              ): Raw.t_dogOrHuman
+            )
+          };
+        };
+        {dogOrHuman: dogOrHuman};
+      }: Raw.t
+    );
+  let definition = (parse, query, serialize);
+};
+module ByDirective = {
+  module Raw = {
+    type t_dogOrHuman_Dog = {
+      __typename: string,
+      name: string,
+      barkVolume: float,
+    };
+    type t_dogOrHuman_Human = {
+      __typename: string,
+      name: string,
+    };
+    type t_dogOrHuman;
+    type t = {dogOrHuman: t_dogOrHuman};
+  };
+  let query = "query   {\ndogOrHuman @ppxOmitFutureValue {\n__typename\n...on Dog   {\n__typename  \nname  \nbarkVolume  \n}\n\n...on Human   {\n__typename  \nname  \n}\n\n}\n\n}\n";
+  type t_dogOrHuman_Dog = {
+    __typename: string,
+    name: string,
+    barkVolume: float,
+  };
+  type t_dogOrHuman_Human = {
+    __typename: string,
+    name: string,
+  };
+  type t_dogOrHuman = [
+    | `Dog(t_dogOrHuman_Dog)
+    | `Human(t_dogOrHuman_Human)
+  ];
+  type t = {dogOrHuman: t_dogOrHuman};
+  type operation = t;
+  let parse: Raw.t => t =
+    (value) => (
+      {
+        dogOrHuman: {
+          let value = (value: Raw.t).dogOrHuman;
+          let typename: string =
+            Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "__typename"));
+          (
+            switch (typename) {
+            | "Dog" =>
+              `Dog(
+                {
+                  let value: Raw.t_dogOrHuman_Dog = Obj.magic(value);
+                  (
+                    {
+                      __typename: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).__typename;
+                        value;
+                      },
+                      name: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).name;
+                        value;
+                      },
+                      barkVolume: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).barkVolume;
+                        value;
+                      },
+                    }: t_dogOrHuman_Dog
+                  );
+                },
+              )
+            | "Human" =>
+              `Human(
+                {
+                  let value: Raw.t_dogOrHuman_Human = Obj.magic(value);
+                  (
+                    {
+                      __typename: {
+                        let value = (value: Raw.t_dogOrHuman_Human).__typename;
+                        value;
+                      },
+                      name: {
+                        let value = (value: Raw.t_dogOrHuman_Human).name;
+                        value;
+                      },
+                    }: t_dogOrHuman_Human
+                  );
+                },
+              )
+            | _ => raise(Not_found)
+            }: t_dogOrHuman
+          );
+        },
+      }: t
+    );
+  let serialize: t => Raw.t =
+    (value) => (
+      {
+        let dogOrHuman = {
+          let value = (value: t).dogOrHuman;
+          switch (value) {
+          | `Dog(value) => (
+              Obj.magic(
+                {
+                  let barkVolume = {
+                    let value = (value: t_dogOrHuman_Dog).barkVolume;
+                    value;
+                  }
+                  and name = {
+                    let value = (value: t_dogOrHuman_Dog).name;
+                    value;
+                  }
+                  and __typename = {
+                    let value = (value: t_dogOrHuman_Dog).__typename;
+                    value;
+                  };
+                  {__typename: "Dog", name, barkVolume};
+                }: Raw.t_dogOrHuman_Dog,
+              ): Raw.t_dogOrHuman
+            )
+          | `Human(value) => (
+              Obj.magic(
+                {
+                  let name = {
+                    let value = (value: t_dogOrHuman_Human).name;
+                    value;
+                  }
+                  and __typename = {
+                    let value = (value: t_dogOrHuman_Human).__typename;
+                    value;
+                  };
+                  {__typename: "Human", name};
+                }: Raw.t_dogOrHuman_Human,
+              ): Raw.t_dogOrHuman
+            )
+          };
+        };
+        {dogOrHuman: dogOrHuman};
+      }: Raw.t
+    );
+  let definition = (parse, query, serialize);
+};

--- a/tests_bucklescript/static_snapshots/legacy/operations/omitFutureValueEnum.re
+++ b/tests_bucklescript/static_snapshots/legacy/operations/omitFutureValueEnum.re
@@ -1,0 +1,327 @@
+[@ocaml.ppx.context
+  {
+    tool_name: "migrate_driver",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module Normal = {
+  module Raw = {
+    type t_mutationWithError_errors_field = string;
+    type t_mutationWithError_errors = {
+      .
+      "message": string,
+      "field": t_mutationWithError_errors_field,
+    };
+    type t_mutationWithError = {
+      .
+      "errors": Js.Nullable.t(array(t_mutationWithError_errors)),
+    };
+    type t = {. "mutationWithError": t_mutationWithError};
+  };
+  let query = "mutation   {\nmutationWithError  {\nerrors  {\nmessage  \nfield  \n}\n\n}\n\n}\n";
+  type t_mutationWithError_errors_field = [
+    | `FutureAddedValue(string)
+    | `FIRST
+    | `SECOND
+    | `THIRD
+  ];
+  type t_mutationWithError_errors = {
+    .
+    "message": string,
+    "field": t_mutationWithError_errors_field,
+  };
+  type t_mutationWithError = {
+    .
+    "errors": option(array(t_mutationWithError_errors)),
+  };
+  type t = {. "mutationWithError": t_mutationWithError};
+  type operation = t;
+  let parse: Raw.t => t =
+    value => {
+      let mutationWithError = {
+        let value = value##mutationWithError;
+        let errors = {
+          let value = value##errors;
+          switch (Js.toOption(value)) {
+          | Some(value) =>
+            Some(
+              value
+              |> Js.Array.map(value =>
+                   let field = {
+                     let value = value##field;
+                     switch (Obj.magic(value: string)) {
+                     | "FIRST" => `FIRST
+                     | "SECOND" => `SECOND
+                     | "THIRD" => `THIRD
+                     | other => `FutureAddedValue(other)
+                     };
+                   }
+                   and message = {
+                     let value = value##message;
+                     value;
+                   };
+                   {"message": message, "field": field};
+                 ),
+            )
+          | None => None
+          };
+        };
+        {"errors": errors};
+      };
+      {"mutationWithError": mutationWithError};
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let mutationWithError = {
+        let value = value##mutationWithError;
+        let errors = {
+          let value = value##errors;
+          switch (value) {
+          | Some(value) =>
+            Js.Nullable.return(
+              value
+              |> Js.Array.map(value =>
+                   let field = {
+                     let value = value##field;
+                     switch (value) {
+                     | `FIRST => "FIRST"
+                     | `SECOND => "SECOND"
+                     | `THIRD => "THIRD"
+                     | `FutureAddedValue(other) => other
+                     };
+                   }
+                   and message = {
+                     let value = value##message;
+                     value;
+                   };
+                   {"message": message, "field": field};
+                 ),
+            )
+          | None => Js.Nullable.null
+          };
+        };
+        {"errors": errors};
+      };
+      {"mutationWithError": mutationWithError};
+    };
+  let make = () => {
+    "query": query,
+    "variables": Js.Json.null,
+    "parse": parse,
+  };
+  let definition = (parse, query, serialize);
+};
+module ByConfig = {
+  module Raw = {
+    type t_mutationWithError_errors_field = string;
+    type t_mutationWithError_errors = {
+      .
+      "message": string,
+      "field": t_mutationWithError_errors_field,
+    };
+    type t_mutationWithError = {
+      .
+      "errors": Js.Nullable.t(array(t_mutationWithError_errors)),
+    };
+    type t = {. "mutationWithError": t_mutationWithError};
+  };
+  let query = "mutation   {\nmutationWithError  {\nerrors  {\nmessage  \nfield  \n}\n\n}\n\n}\n";
+  type t_mutationWithError_errors_field = [ | `FIRST | `SECOND | `THIRD];
+  type t_mutationWithError_errors = {
+    .
+    "message": string,
+    "field": t_mutationWithError_errors_field,
+  };
+  type t_mutationWithError = {
+    .
+    "errors": option(array(t_mutationWithError_errors)),
+  };
+  type t = {. "mutationWithError": t_mutationWithError};
+  type operation = t;
+  let parse: Raw.t => t =
+    value => {
+      let mutationWithError = {
+        let value = value##mutationWithError;
+        let errors = {
+          let value = value##errors;
+          switch (Js.toOption(value)) {
+          | Some(value) =>
+            Some(
+              value
+              |> Js.Array.map(value =>
+                   let field = {
+                     let value = value##field;
+                     switch (Obj.magic(value: string)) {
+                     | "FIRST" => `FIRST
+                     | "SECOND" => `SECOND
+                     | "THIRD" => `THIRD
+                     | _ => raise(Not_found)
+                     };
+                   }
+                   and message = {
+                     let value = value##message;
+                     value;
+                   };
+                   {"message": message, "field": field};
+                 ),
+            )
+          | None => None
+          };
+        };
+        {"errors": errors};
+      };
+      {"mutationWithError": mutationWithError};
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let mutationWithError = {
+        let value = value##mutationWithError;
+        let errors = {
+          let value = value##errors;
+          switch (value) {
+          | Some(value) =>
+            Js.Nullable.return(
+              value
+              |> Js.Array.map(value =>
+                   let field = {
+                     let value = value##field;
+                     switch (value) {
+                     | `FIRST => "FIRST"
+                     | `SECOND => "SECOND"
+                     | `THIRD => "THIRD"
+                     };
+                   }
+                   and message = {
+                     let value = value##message;
+                     value;
+                   };
+                   {"message": message, "field": field};
+                 ),
+            )
+          | None => Js.Nullable.null
+          };
+        };
+        {"errors": errors};
+      };
+      {"mutationWithError": mutationWithError};
+    };
+  let make = () => {
+    "query": query,
+    "variables": Js.Json.null,
+    "parse": parse,
+  };
+  let definition = (parse, query, serialize);
+};
+module ByDirective = {
+  module Raw = {
+    type t_mutationWithError_errors_field = string;
+    type t_mutationWithError_errors = {
+      .
+      "message": string,
+      "field": t_mutationWithError_errors_field,
+    };
+    type t_mutationWithError = {
+      .
+      "errors": Js.Nullable.t(array(t_mutationWithError_errors)),
+    };
+    type t = {. "mutationWithError": t_mutationWithError};
+  };
+  let query = "mutation   {\nmutationWithError  {\nerrors  {\nmessage  \nfield @ppxOmitFutureValue \n}\n\n}\n\n}\n";
+  type t_mutationWithError_errors_field = [ | `FIRST | `SECOND | `THIRD];
+  type t_mutationWithError_errors = {
+    .
+    "message": string,
+    "field": t_mutationWithError_errors_field,
+  };
+  type t_mutationWithError = {
+    .
+    "errors": option(array(t_mutationWithError_errors)),
+  };
+  type t = {. "mutationWithError": t_mutationWithError};
+  type operation = t;
+  let parse: Raw.t => t =
+    value => {
+      let mutationWithError = {
+        let value = value##mutationWithError;
+        let errors = {
+          let value = value##errors;
+          switch (Js.toOption(value)) {
+          | Some(value) =>
+            Some(
+              value
+              |> Js.Array.map(value =>
+                   let field = {
+                     let value = value##field;
+                     switch (Obj.magic(value: string)) {
+                     | "FIRST" => `FIRST
+                     | "SECOND" => `SECOND
+                     | "THIRD" => `THIRD
+                     | _ => raise(Not_found)
+                     };
+                   }
+                   and message = {
+                     let value = value##message;
+                     value;
+                   };
+                   {"message": message, "field": field};
+                 ),
+            )
+          | None => None
+          };
+        };
+        {"errors": errors};
+      };
+      {"mutationWithError": mutationWithError};
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let mutationWithError = {
+        let value = value##mutationWithError;
+        let errors = {
+          let value = value##errors;
+          switch (value) {
+          | Some(value) =>
+            Js.Nullable.return(
+              value
+              |> Js.Array.map(value =>
+                   let field = {
+                     let value = value##field;
+                     switch (value) {
+                     | `FIRST => "FIRST"
+                     | `SECOND => "SECOND"
+                     | `THIRD => "THIRD"
+                     };
+                   }
+                   and message = {
+                     let value = value##message;
+                     value;
+                   };
+                   {"message": message, "field": field};
+                 ),
+            )
+          | None => Js.Nullable.null
+          };
+        };
+        {"errors": errors};
+      };
+      {"mutationWithError": mutationWithError};
+    };
+  let make = () => {
+    "query": query,
+    "variables": Js.Json.null,
+    "parse": parse,
+  };
+  let definition = (parse, query, serialize);
+};

--- a/tests_bucklescript/static_snapshots/legacy/operations/omitFutureValueUnion.re
+++ b/tests_bucklescript/static_snapshots/legacy/operations/omitFutureValueUnion.re
@@ -1,0 +1,353 @@
+[@ocaml.ppx.context
+  {
+    tool_name: "migrate_driver",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module Normal = {
+  module Raw = {
+    type t_dogOrHuman_Dog = {
+      .
+      "__typename": string,
+      "name": string,
+      "barkVolume": float,
+    };
+    type t_dogOrHuman_Human = {
+      .
+      "__typename": string,
+      "name": string,
+    };
+    type t_dogOrHuman;
+    type t = {. "dogOrHuman": t_dogOrHuman};
+  };
+  let query = "query   {\ndogOrHuman  {\n__typename\n...on Dog   {\nname  \nbarkVolume  \n}\n\n...on Human   {\nname  \n}\n\n}\n\n}\n";
+  type t_dogOrHuman_Dog = {
+    .
+    "name": string,
+    "barkVolume": float,
+  };
+  type t_dogOrHuman_Human = {. "name": string};
+  type t_dogOrHuman = [
+    | `FutureAddedValue(Js.Json.t)
+    | `Dog(t_dogOrHuman_Dog)
+    | `Human(t_dogOrHuman_Human)
+  ];
+  type t = {. "dogOrHuman": t_dogOrHuman};
+  type operation = t;
+  let parse: Raw.t => t =
+    value => {
+      let dogOrHuman = {
+        let value = value##dogOrHuman;
+        let typename: string =
+          Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "__typename"));
+        (
+          switch (typename) {
+          | "Dog" =>
+            `Dog(
+              {
+                let value: Raw.t_dogOrHuman_Dog = Obj.magic(value);
+                let barkVolume = {
+                  let value = value##barkVolume;
+                  value;
+                }
+                and name = {
+                  let value = value##name;
+                  value;
+                };
+                {"name": name, "barkVolume": barkVolume};
+              },
+            )
+          | "Human" =>
+            `Human(
+              {
+                let value: Raw.t_dogOrHuman_Human = Obj.magic(value);
+                let name = {
+                  let value = value##name;
+                  value;
+                };
+                {"name": name};
+              },
+            )
+          | _ => `FutureAddedValue(Obj.magic(value): Js.Json.t)
+          }: t_dogOrHuman
+        );
+      };
+      {"dogOrHuman": dogOrHuman};
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let dogOrHuman = {
+        let value = value##dogOrHuman;
+        switch (value) {
+        | `Dog(value) => (
+            Obj.magic(
+              {
+                let barkVolume = {
+                  let value = value##barkVolume;
+                  value;
+                }
+                and name = {
+                  let value = value##name;
+                  value;
+                };
+                {"__typename": "Dog", "name": name, "barkVolume": barkVolume};
+              },
+            ): Raw.t_dogOrHuman
+          )
+        | `Human(value) => (
+            Obj.magic(
+              {
+                let name = {
+                  let value = value##name;
+                  value;
+                };
+                {"__typename": "Human", "name": name};
+              },
+            ): Raw.t_dogOrHuman
+          )
+        | `FutureAddedValue(value) => (Obj.magic(value): Raw.t_dogOrHuman)
+        };
+      };
+      {"dogOrHuman": dogOrHuman};
+    };
+  let make = () => {
+    "query": query,
+    "variables": Js.Json.null,
+    "parse": parse,
+  };
+  let definition = (parse, query, serialize);
+};
+module ByConfig = {
+  module Raw = {
+    type t_dogOrHuman_Dog = {
+      .
+      "__typename": string,
+      "name": string,
+      "barkVolume": float,
+    };
+    type t_dogOrHuman_Human = {
+      .
+      "__typename": string,
+      "name": string,
+    };
+    type t_dogOrHuman;
+    type t = {. "dogOrHuman": t_dogOrHuman};
+  };
+  let query = "query   {\ndogOrHuman  {\n__typename\n...on Dog   {\nname  \nbarkVolume  \n}\n\n...on Human   {\nname  \n}\n\n}\n\n}\n";
+  type t_dogOrHuman_Dog = {
+    .
+    "name": string,
+    "barkVolume": float,
+  };
+  type t_dogOrHuman_Human = {. "name": string};
+  type t_dogOrHuman = [
+    | `Dog(t_dogOrHuman_Dog)
+    | `Human(t_dogOrHuman_Human)
+  ];
+  type t = {. "dogOrHuman": t_dogOrHuman};
+  type operation = t;
+  let parse: Raw.t => t =
+    value => {
+      let dogOrHuman = {
+        let value = value##dogOrHuman;
+        let typename: string =
+          Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "__typename"));
+        (
+          switch (typename) {
+          | "Dog" =>
+            `Dog(
+              {
+                let value: Raw.t_dogOrHuman_Dog = Obj.magic(value);
+                let barkVolume = {
+                  let value = value##barkVolume;
+                  value;
+                }
+                and name = {
+                  let value = value##name;
+                  value;
+                };
+                {"name": name, "barkVolume": barkVolume};
+              },
+            )
+          | "Human" =>
+            `Human(
+              {
+                let value: Raw.t_dogOrHuman_Human = Obj.magic(value);
+                let name = {
+                  let value = value##name;
+                  value;
+                };
+                {"name": name};
+              },
+            )
+          | _ => raise(Not_found)
+          }: t_dogOrHuman
+        );
+      };
+      {"dogOrHuman": dogOrHuman};
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let dogOrHuman = {
+        let value = value##dogOrHuman;
+        switch (value) {
+        | `Dog(value) => (
+            Obj.magic(
+              {
+                let barkVolume = {
+                  let value = value##barkVolume;
+                  value;
+                }
+                and name = {
+                  let value = value##name;
+                  value;
+                };
+                {"__typename": "Dog", "name": name, "barkVolume": barkVolume};
+              },
+            ): Raw.t_dogOrHuman
+          )
+        | `Human(value) => (
+            Obj.magic(
+              {
+                let name = {
+                  let value = value##name;
+                  value;
+                };
+                {"__typename": "Human", "name": name};
+              },
+            ): Raw.t_dogOrHuman
+          )
+        };
+      };
+      {"dogOrHuman": dogOrHuman};
+    };
+  let make = () => {
+    "query": query,
+    "variables": Js.Json.null,
+    "parse": parse,
+  };
+  let definition = (parse, query, serialize);
+};
+module ByDirective = {
+  module Raw = {
+    type t_dogOrHuman_Dog = {
+      .
+      "__typename": string,
+      "name": string,
+      "barkVolume": float,
+    };
+    type t_dogOrHuman_Human = {
+      .
+      "__typename": string,
+      "name": string,
+    };
+    type t_dogOrHuman;
+    type t = {. "dogOrHuman": t_dogOrHuman};
+  };
+  let query = "query   {\ndogOrHuman @ppxOmitFutureValue {\n__typename\n...on Dog   {\nname  \nbarkVolume  \n}\n\n...on Human   {\nname  \n}\n\n}\n\n}\n";
+  type t_dogOrHuman_Dog = {
+    .
+    "name": string,
+    "barkVolume": float,
+  };
+  type t_dogOrHuman_Human = {. "name": string};
+  type t_dogOrHuman = [
+    | `Dog(t_dogOrHuman_Dog)
+    | `Human(t_dogOrHuman_Human)
+  ];
+  type t = {. "dogOrHuman": t_dogOrHuman};
+  type operation = t;
+  let parse: Raw.t => t =
+    value => {
+      let dogOrHuman = {
+        let value = value##dogOrHuman;
+        let typename: string =
+          Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "__typename"));
+        (
+          switch (typename) {
+          | "Dog" =>
+            `Dog(
+              {
+                let value: Raw.t_dogOrHuman_Dog = Obj.magic(value);
+                let barkVolume = {
+                  let value = value##barkVolume;
+                  value;
+                }
+                and name = {
+                  let value = value##name;
+                  value;
+                };
+                {"name": name, "barkVolume": barkVolume};
+              },
+            )
+          | "Human" =>
+            `Human(
+              {
+                let value: Raw.t_dogOrHuman_Human = Obj.magic(value);
+                let name = {
+                  let value = value##name;
+                  value;
+                };
+                {"name": name};
+              },
+            )
+          | _ => raise(Not_found)
+          }: t_dogOrHuman
+        );
+      };
+      {"dogOrHuman": dogOrHuman};
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let dogOrHuman = {
+        let value = value##dogOrHuman;
+        switch (value) {
+        | `Dog(value) => (
+            Obj.magic(
+              {
+                let barkVolume = {
+                  let value = value##barkVolume;
+                  value;
+                }
+                and name = {
+                  let value = value##name;
+                  value;
+                };
+                {"__typename": "Dog", "name": name, "barkVolume": barkVolume};
+              },
+            ): Raw.t_dogOrHuman
+          )
+        | `Human(value) => (
+            Obj.magic(
+              {
+                let name = {
+                  let value = value##name;
+                  value;
+                };
+                {"__typename": "Human", "name": name};
+              },
+            ): Raw.t_dogOrHuman
+          )
+        };
+      };
+      {"dogOrHuman": dogOrHuman};
+    };
+  let make = () => {
+    "query": query,
+    "variables": Js.Json.null,
+    "parse": parse,
+  };
+  let definition = (parse, query, serialize);
+};

--- a/tests_bucklescript/static_snapshots/objects/operations/omitFutureValueEnum.re
+++ b/tests_bucklescript/static_snapshots/objects/operations/omitFutureValueEnum.re
@@ -1,0 +1,312 @@
+[@ocaml.ppx.context
+  {
+    tool_name: "migrate_driver",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module Normal = {
+  module Raw = {
+    type t_mutationWithError_errors_field = string;
+    type t_mutationWithError_errors = {
+      .
+      "message": string,
+      "field": t_mutationWithError_errors_field,
+    };
+    type t_mutationWithError = {
+      .
+      "errors": Js.Nullable.t(array(t_mutationWithError_errors)),
+    };
+    type t = {. "mutationWithError": t_mutationWithError};
+  };
+  let query = "mutation   {\nmutationWithError  {\nerrors  {\nmessage  \nfield  \n}\n\n}\n\n}\n";
+  type t_mutationWithError_errors_field = [
+    | `FutureAddedValue(string)
+    | `FIRST
+    | `SECOND
+    | `THIRD
+  ];
+  type t_mutationWithError_errors = {
+    .
+    "message": string,
+    "field": t_mutationWithError_errors_field,
+  };
+  type t_mutationWithError = {
+    .
+    "errors": option(array(t_mutationWithError_errors)),
+  };
+  type t = {. "mutationWithError": t_mutationWithError};
+  type operation = t;
+  let parse: Raw.t => t =
+    value => {
+      let mutationWithError = {
+        let value = value##mutationWithError;
+        let errors = {
+          let value = value##errors;
+          switch (Js.toOption(value)) {
+          | Some(value) =>
+            Some(
+              value
+              |> Js.Array.map(value =>
+                   let field = {
+                     let value = value##field;
+                     switch (Obj.magic(value: string)) {
+                     | "FIRST" => `FIRST
+                     | "SECOND" => `SECOND
+                     | "THIRD" => `THIRD
+                     | other => `FutureAddedValue(other)
+                     };
+                   }
+                   and message = {
+                     let value = value##message;
+                     value;
+                   };
+                   {"message": message, "field": field};
+                 ),
+            )
+          | None => None
+          };
+        };
+        {"errors": errors};
+      };
+      {"mutationWithError": mutationWithError};
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let mutationWithError = {
+        let value = value##mutationWithError;
+        let errors = {
+          let value = value##errors;
+          switch (value) {
+          | Some(value) =>
+            Js.Nullable.return(
+              value
+              |> Js.Array.map(value =>
+                   let field = {
+                     let value = value##field;
+                     switch (value) {
+                     | `FIRST => "FIRST"
+                     | `SECOND => "SECOND"
+                     | `THIRD => "THIRD"
+                     | `FutureAddedValue(other) => other
+                     };
+                   }
+                   and message = {
+                     let value = value##message;
+                     value;
+                   };
+                   {"message": message, "field": field};
+                 ),
+            )
+          | None => Js.Nullable.null
+          };
+        };
+        {"errors": errors};
+      };
+      {"mutationWithError": mutationWithError};
+    };
+  let definition = (parse, query, serialize);
+};
+module ByConfig = {
+  module Raw = {
+    type t_mutationWithError_errors_field = string;
+    type t_mutationWithError_errors = {
+      .
+      "message": string,
+      "field": t_mutationWithError_errors_field,
+    };
+    type t_mutationWithError = {
+      .
+      "errors": Js.Nullable.t(array(t_mutationWithError_errors)),
+    };
+    type t = {. "mutationWithError": t_mutationWithError};
+  };
+  let query = "mutation   {\nmutationWithError  {\nerrors  {\nmessage  \nfield  \n}\n\n}\n\n}\n";
+  type t_mutationWithError_errors_field = [ | `FIRST | `SECOND | `THIRD];
+  type t_mutationWithError_errors = {
+    .
+    "message": string,
+    "field": t_mutationWithError_errors_field,
+  };
+  type t_mutationWithError = {
+    .
+    "errors": option(array(t_mutationWithError_errors)),
+  };
+  type t = {. "mutationWithError": t_mutationWithError};
+  type operation = t;
+  let parse: Raw.t => t =
+    value => {
+      let mutationWithError = {
+        let value = value##mutationWithError;
+        let errors = {
+          let value = value##errors;
+          switch (Js.toOption(value)) {
+          | Some(value) =>
+            Some(
+              value
+              |> Js.Array.map(value =>
+                   let field = {
+                     let value = value##field;
+                     switch (Obj.magic(value: string)) {
+                     | "FIRST" => `FIRST
+                     | "SECOND" => `SECOND
+                     | "THIRD" => `THIRD
+                     | _ => raise(Not_found)
+                     };
+                   }
+                   and message = {
+                     let value = value##message;
+                     value;
+                   };
+                   {"message": message, "field": field};
+                 ),
+            )
+          | None => None
+          };
+        };
+        {"errors": errors};
+      };
+      {"mutationWithError": mutationWithError};
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let mutationWithError = {
+        let value = value##mutationWithError;
+        let errors = {
+          let value = value##errors;
+          switch (value) {
+          | Some(value) =>
+            Js.Nullable.return(
+              value
+              |> Js.Array.map(value =>
+                   let field = {
+                     let value = value##field;
+                     switch (value) {
+                     | `FIRST => "FIRST"
+                     | `SECOND => "SECOND"
+                     | `THIRD => "THIRD"
+                     };
+                   }
+                   and message = {
+                     let value = value##message;
+                     value;
+                   };
+                   {"message": message, "field": field};
+                 ),
+            )
+          | None => Js.Nullable.null
+          };
+        };
+        {"errors": errors};
+      };
+      {"mutationWithError": mutationWithError};
+    };
+  let definition = (parse, query, serialize);
+};
+module ByDirective = {
+  module Raw = {
+    type t_mutationWithError_errors_field = string;
+    type t_mutationWithError_errors = {
+      .
+      "message": string,
+      "field": t_mutationWithError_errors_field,
+    };
+    type t_mutationWithError = {
+      .
+      "errors": Js.Nullable.t(array(t_mutationWithError_errors)),
+    };
+    type t = {. "mutationWithError": t_mutationWithError};
+  };
+  let query = "mutation   {\nmutationWithError  {\nerrors  {\nmessage  \nfield @ppxOmitFutureValue \n}\n\n}\n\n}\n";
+  type t_mutationWithError_errors_field = [ | `FIRST | `SECOND | `THIRD];
+  type t_mutationWithError_errors = {
+    .
+    "message": string,
+    "field": t_mutationWithError_errors_field,
+  };
+  type t_mutationWithError = {
+    .
+    "errors": option(array(t_mutationWithError_errors)),
+  };
+  type t = {. "mutationWithError": t_mutationWithError};
+  type operation = t;
+  let parse: Raw.t => t =
+    value => {
+      let mutationWithError = {
+        let value = value##mutationWithError;
+        let errors = {
+          let value = value##errors;
+          switch (Js.toOption(value)) {
+          | Some(value) =>
+            Some(
+              value
+              |> Js.Array.map(value =>
+                   let field = {
+                     let value = value##field;
+                     switch (Obj.magic(value: string)) {
+                     | "FIRST" => `FIRST
+                     | "SECOND" => `SECOND
+                     | "THIRD" => `THIRD
+                     | _ => raise(Not_found)
+                     };
+                   }
+                   and message = {
+                     let value = value##message;
+                     value;
+                   };
+                   {"message": message, "field": field};
+                 ),
+            )
+          | None => None
+          };
+        };
+        {"errors": errors};
+      };
+      {"mutationWithError": mutationWithError};
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let mutationWithError = {
+        let value = value##mutationWithError;
+        let errors = {
+          let value = value##errors;
+          switch (value) {
+          | Some(value) =>
+            Js.Nullable.return(
+              value
+              |> Js.Array.map(value =>
+                   let field = {
+                     let value = value##field;
+                     switch (value) {
+                     | `FIRST => "FIRST"
+                     | `SECOND => "SECOND"
+                     | `THIRD => "THIRD"
+                     };
+                   }
+                   and message = {
+                     let value = value##message;
+                     value;
+                   };
+                   {"message": message, "field": field};
+                 ),
+            )
+          | None => Js.Nullable.null
+          };
+        };
+        {"errors": errors};
+      };
+      {"mutationWithError": mutationWithError};
+    };
+  let definition = (parse, query, serialize);
+};

--- a/tests_bucklescript/static_snapshots/objects/operations/omitFutureValueUnion.re
+++ b/tests_bucklescript/static_snapshots/objects/operations/omitFutureValueUnion.re
@@ -1,0 +1,338 @@
+[@ocaml.ppx.context
+  {
+    tool_name: "migrate_driver",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module Normal = {
+  module Raw = {
+    type t_dogOrHuman_Dog = {
+      .
+      "__typename": string,
+      "name": string,
+      "barkVolume": float,
+    };
+    type t_dogOrHuman_Human = {
+      .
+      "__typename": string,
+      "name": string,
+    };
+    type t_dogOrHuman;
+    type t = {. "dogOrHuman": t_dogOrHuman};
+  };
+  let query = "query   {\ndogOrHuman  {\n__typename\n...on Dog   {\nname  \nbarkVolume  \n}\n\n...on Human   {\nname  \n}\n\n}\n\n}\n";
+  type t_dogOrHuman_Dog = {
+    .
+    "name": string,
+    "barkVolume": float,
+  };
+  type t_dogOrHuman_Human = {. "name": string};
+  type t_dogOrHuman = [
+    | `FutureAddedValue(Js.Json.t)
+    | `Dog(t_dogOrHuman_Dog)
+    | `Human(t_dogOrHuman_Human)
+  ];
+  type t = {. "dogOrHuman": t_dogOrHuman};
+  type operation = t;
+  let parse: Raw.t => t =
+    value => {
+      let dogOrHuman = {
+        let value = value##dogOrHuman;
+        let typename: string =
+          Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "__typename"));
+        (
+          switch (typename) {
+          | "Dog" =>
+            `Dog(
+              {
+                let value: Raw.t_dogOrHuman_Dog = Obj.magic(value);
+                let barkVolume = {
+                  let value = value##barkVolume;
+                  value;
+                }
+                and name = {
+                  let value = value##name;
+                  value;
+                };
+                {"name": name, "barkVolume": barkVolume};
+              },
+            )
+          | "Human" =>
+            `Human(
+              {
+                let value: Raw.t_dogOrHuman_Human = Obj.magic(value);
+                let name = {
+                  let value = value##name;
+                  value;
+                };
+                {"name": name};
+              },
+            )
+          | _ => `FutureAddedValue(Obj.magic(value): Js.Json.t)
+          }: t_dogOrHuman
+        );
+      };
+      {"dogOrHuman": dogOrHuman};
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let dogOrHuman = {
+        let value = value##dogOrHuman;
+        switch (value) {
+        | `Dog(value) => (
+            Obj.magic(
+              {
+                let barkVolume = {
+                  let value = value##barkVolume;
+                  value;
+                }
+                and name = {
+                  let value = value##name;
+                  value;
+                };
+                {"__typename": "Dog", "name": name, "barkVolume": barkVolume};
+              },
+            ): Raw.t_dogOrHuman
+          )
+        | `Human(value) => (
+            Obj.magic(
+              {
+                let name = {
+                  let value = value##name;
+                  value;
+                };
+                {"__typename": "Human", "name": name};
+              },
+            ): Raw.t_dogOrHuman
+          )
+        | `FutureAddedValue(value) => (Obj.magic(value): Raw.t_dogOrHuman)
+        };
+      };
+      {"dogOrHuman": dogOrHuman};
+    };
+  let definition = (parse, query, serialize);
+};
+module ByConfig = {
+  module Raw = {
+    type t_dogOrHuman_Dog = {
+      .
+      "__typename": string,
+      "name": string,
+      "barkVolume": float,
+    };
+    type t_dogOrHuman_Human = {
+      .
+      "__typename": string,
+      "name": string,
+    };
+    type t_dogOrHuman;
+    type t = {. "dogOrHuman": t_dogOrHuman};
+  };
+  let query = "query   {\ndogOrHuman  {\n__typename\n...on Dog   {\nname  \nbarkVolume  \n}\n\n...on Human   {\nname  \n}\n\n}\n\n}\n";
+  type t_dogOrHuman_Dog = {
+    .
+    "name": string,
+    "barkVolume": float,
+  };
+  type t_dogOrHuman_Human = {. "name": string};
+  type t_dogOrHuman = [
+    | `Dog(t_dogOrHuman_Dog)
+    | `Human(t_dogOrHuman_Human)
+  ];
+  type t = {. "dogOrHuman": t_dogOrHuman};
+  type operation = t;
+  let parse: Raw.t => t =
+    value => {
+      let dogOrHuman = {
+        let value = value##dogOrHuman;
+        let typename: string =
+          Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "__typename"));
+        (
+          switch (typename) {
+          | "Dog" =>
+            `Dog(
+              {
+                let value: Raw.t_dogOrHuman_Dog = Obj.magic(value);
+                let barkVolume = {
+                  let value = value##barkVolume;
+                  value;
+                }
+                and name = {
+                  let value = value##name;
+                  value;
+                };
+                {"name": name, "barkVolume": barkVolume};
+              },
+            )
+          | "Human" =>
+            `Human(
+              {
+                let value: Raw.t_dogOrHuman_Human = Obj.magic(value);
+                let name = {
+                  let value = value##name;
+                  value;
+                };
+                {"name": name};
+              },
+            )
+          | _ => raise(Not_found)
+          }: t_dogOrHuman
+        );
+      };
+      {"dogOrHuman": dogOrHuman};
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let dogOrHuman = {
+        let value = value##dogOrHuman;
+        switch (value) {
+        | `Dog(value) => (
+            Obj.magic(
+              {
+                let barkVolume = {
+                  let value = value##barkVolume;
+                  value;
+                }
+                and name = {
+                  let value = value##name;
+                  value;
+                };
+                {"__typename": "Dog", "name": name, "barkVolume": barkVolume};
+              },
+            ): Raw.t_dogOrHuman
+          )
+        | `Human(value) => (
+            Obj.magic(
+              {
+                let name = {
+                  let value = value##name;
+                  value;
+                };
+                {"__typename": "Human", "name": name};
+              },
+            ): Raw.t_dogOrHuman
+          )
+        };
+      };
+      {"dogOrHuman": dogOrHuman};
+    };
+  let definition = (parse, query, serialize);
+};
+module ByDirective = {
+  module Raw = {
+    type t_dogOrHuman_Dog = {
+      .
+      "__typename": string,
+      "name": string,
+      "barkVolume": float,
+    };
+    type t_dogOrHuman_Human = {
+      .
+      "__typename": string,
+      "name": string,
+    };
+    type t_dogOrHuman;
+    type t = {. "dogOrHuman": t_dogOrHuman};
+  };
+  let query = "query   {\ndogOrHuman @ppxOmitFutureValue {\n__typename\n...on Dog   {\nname  \nbarkVolume  \n}\n\n...on Human   {\nname  \n}\n\n}\n\n}\n";
+  type t_dogOrHuman_Dog = {
+    .
+    "name": string,
+    "barkVolume": float,
+  };
+  type t_dogOrHuman_Human = {. "name": string};
+  type t_dogOrHuman = [
+    | `Dog(t_dogOrHuman_Dog)
+    | `Human(t_dogOrHuman_Human)
+  ];
+  type t = {. "dogOrHuman": t_dogOrHuman};
+  type operation = t;
+  let parse: Raw.t => t =
+    value => {
+      let dogOrHuman = {
+        let value = value##dogOrHuman;
+        let typename: string =
+          Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "__typename"));
+        (
+          switch (typename) {
+          | "Dog" =>
+            `Dog(
+              {
+                let value: Raw.t_dogOrHuman_Dog = Obj.magic(value);
+                let barkVolume = {
+                  let value = value##barkVolume;
+                  value;
+                }
+                and name = {
+                  let value = value##name;
+                  value;
+                };
+                {"name": name, "barkVolume": barkVolume};
+              },
+            )
+          | "Human" =>
+            `Human(
+              {
+                let value: Raw.t_dogOrHuman_Human = Obj.magic(value);
+                let name = {
+                  let value = value##name;
+                  value;
+                };
+                {"name": name};
+              },
+            )
+          | _ => raise(Not_found)
+          }: t_dogOrHuman
+        );
+      };
+      {"dogOrHuman": dogOrHuman};
+    };
+  let serialize: t => Raw.t =
+    value => {
+      let dogOrHuman = {
+        let value = value##dogOrHuman;
+        switch (value) {
+        | `Dog(value) => (
+            Obj.magic(
+              {
+                let barkVolume = {
+                  let value = value##barkVolume;
+                  value;
+                }
+                and name = {
+                  let value = value##name;
+                  value;
+                };
+                {"__typename": "Dog", "name": name, "barkVolume": barkVolume};
+              },
+            ): Raw.t_dogOrHuman
+          )
+        | `Human(value) => (
+            Obj.magic(
+              {
+                let name = {
+                  let value = value##name;
+                  value;
+                };
+                {"__typename": "Human", "name": name};
+              },
+            ): Raw.t_dogOrHuman
+          )
+        };
+      };
+      {"dogOrHuman": dogOrHuman};
+    };
+  let definition = (parse, query, serialize);
+};

--- a/tests_bucklescript/static_snapshots/records/operations/omitFutureValueEnum.re
+++ b/tests_bucklescript/static_snapshots/records/operations/omitFutureValueEnum.re
@@ -1,0 +1,366 @@
+[@ocaml.ppx.context
+  {
+    tool_name: "migrate_driver",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module Normal = {
+  module Raw = {
+    type t_mutationWithError_errors_field = string;
+    type t_mutationWithError_errors = {
+      message: string,
+      field: t_mutationWithError_errors_field,
+    };
+    type t_mutationWithError = {
+      errors: Js.Nullable.t(array(t_mutationWithError_errors)),
+    };
+    type t = {mutationWithError: t_mutationWithError};
+  };
+  let query = "mutation   {\nmutationWithError  {\nerrors  {\nmessage  \nfield  \n}\n\n}\n\n}\n";
+  type t_mutationWithError_errors_field = [
+    | `FutureAddedValue(string)
+    | `FIRST
+    | `SECOND
+    | `THIRD
+  ];
+  type t_mutationWithError_errors = {
+    message: string,
+    field: t_mutationWithError_errors_field,
+  };
+  type t_mutationWithError = {
+    errors: option(array(t_mutationWithError_errors)),
+  };
+  type t = {mutationWithError: t_mutationWithError};
+  type operation = t;
+  let parse: Raw.t => t =
+    (value) => (
+      {
+        mutationWithError: {
+          let value = (value: Raw.t).mutationWithError;
+          (
+            {
+              errors: {
+                let value = (value: Raw.t_mutationWithError).errors;
+                switch (Js.toOption(value)) {
+                | Some(value) =>
+                  Some(
+                    value
+                    |> Js.Array.map((value) =>
+                         (
+                           {
+                             message: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).
+                                   message;
+                               value;
+                             },
+                             field: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).field;
+                               switch (Obj.magic(value: string)) {
+                               | "FIRST" => `FIRST
+                               | "SECOND" => `SECOND
+                               | "THIRD" => `THIRD
+                               | other => `FutureAddedValue(other)
+                               };
+                             },
+                           }: t_mutationWithError_errors
+                         )
+                       ),
+                  )
+                | None => None
+                };
+              },
+            }: t_mutationWithError
+          );
+        },
+      }: t
+    );
+  let serialize: t => Raw.t =
+    (value) => (
+      {
+        let mutationWithError = {
+          let value = (value: t).mutationWithError;
+          (
+            {
+              let errors = {
+                let value = (value: t_mutationWithError).errors;
+                switch (value) {
+                | Some(value) =>
+                  Js.Nullable.return(
+                    value
+                    |> Js.Array.map((value) =>
+                         (
+                           {
+                             let field = {
+                               let value =
+                                 (value: t_mutationWithError_errors).field;
+                               switch (value) {
+                               | `FIRST => "FIRST"
+                               | `SECOND => "SECOND"
+                               | `THIRD => "THIRD"
+                               | `FutureAddedValue(other) => other
+                               };
+                             }
+                             and message = {
+                               let value =
+                                 (value: t_mutationWithError_errors).message;
+                               value;
+                             };
+                             {message, field};
+                           }: Raw.t_mutationWithError_errors
+                         )
+                       ),
+                  )
+                | None => Js.Nullable.null
+                };
+              };
+              {errors: errors};
+            }: Raw.t_mutationWithError
+          );
+        };
+        {mutationWithError: mutationWithError};
+      }: Raw.t
+    );
+  let definition = (parse, query, serialize);
+};
+module ByConfig = {
+  module Raw = {
+    type t_mutationWithError_errors_field = string;
+    type t_mutationWithError_errors = {
+      message: string,
+      field: t_mutationWithError_errors_field,
+    };
+    type t_mutationWithError = {
+      errors: Js.Nullable.t(array(t_mutationWithError_errors)),
+    };
+    type t = {mutationWithError: t_mutationWithError};
+  };
+  let query = "mutation   {\nmutationWithError  {\nerrors  {\nmessage  \nfield  \n}\n\n}\n\n}\n";
+  type t_mutationWithError_errors_field = [ | `FIRST | `SECOND | `THIRD];
+  type t_mutationWithError_errors = {
+    message: string,
+    field: t_mutationWithError_errors_field,
+  };
+  type t_mutationWithError = {
+    errors: option(array(t_mutationWithError_errors)),
+  };
+  type t = {mutationWithError: t_mutationWithError};
+  type operation = t;
+  let parse: Raw.t => t =
+    (value) => (
+      {
+        mutationWithError: {
+          let value = (value: Raw.t).mutationWithError;
+          (
+            {
+              errors: {
+                let value = (value: Raw.t_mutationWithError).errors;
+                switch (Js.toOption(value)) {
+                | Some(value) =>
+                  Some(
+                    value
+                    |> Js.Array.map((value) =>
+                         (
+                           {
+                             message: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).
+                                   message;
+                               value;
+                             },
+                             field: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).field;
+                               switch (Obj.magic(value: string)) {
+                               | "FIRST" => `FIRST
+                               | "SECOND" => `SECOND
+                               | "THIRD" => `THIRD
+                               | _ => raise(Not_found)
+                               };
+                             },
+                           }: t_mutationWithError_errors
+                         )
+                       ),
+                  )
+                | None => None
+                };
+              },
+            }: t_mutationWithError
+          );
+        },
+      }: t
+    );
+  let serialize: t => Raw.t =
+    (value) => (
+      {
+        let mutationWithError = {
+          let value = (value: t).mutationWithError;
+          (
+            {
+              let errors = {
+                let value = (value: t_mutationWithError).errors;
+                switch (value) {
+                | Some(value) =>
+                  Js.Nullable.return(
+                    value
+                    |> Js.Array.map((value) =>
+                         (
+                           {
+                             let field = {
+                               let value =
+                                 (value: t_mutationWithError_errors).field;
+                               switch (value) {
+                               | `FIRST => "FIRST"
+                               | `SECOND => "SECOND"
+                               | `THIRD => "THIRD"
+                               };
+                             }
+                             and message = {
+                               let value =
+                                 (value: t_mutationWithError_errors).message;
+                               value;
+                             };
+                             {message, field};
+                           }: Raw.t_mutationWithError_errors
+                         )
+                       ),
+                  )
+                | None => Js.Nullable.null
+                };
+              };
+              {errors: errors};
+            }: Raw.t_mutationWithError
+          );
+        };
+        {mutationWithError: mutationWithError};
+      }: Raw.t
+    );
+  let definition = (parse, query, serialize);
+};
+module ByDirective = {
+  module Raw = {
+    type t_mutationWithError_errors_field = string;
+    type t_mutationWithError_errors = {
+      message: string,
+      field: t_mutationWithError_errors_field,
+    };
+    type t_mutationWithError = {
+      errors: Js.Nullable.t(array(t_mutationWithError_errors)),
+    };
+    type t = {mutationWithError: t_mutationWithError};
+  };
+  let query = "mutation   {\nmutationWithError  {\nerrors  {\nmessage  \nfield @ppxOmitFutureValue \n}\n\n}\n\n}\n";
+  type t_mutationWithError_errors_field = [ | `FIRST | `SECOND | `THIRD];
+  type t_mutationWithError_errors = {
+    message: string,
+    field: t_mutationWithError_errors_field,
+  };
+  type t_mutationWithError = {
+    errors: option(array(t_mutationWithError_errors)),
+  };
+  type t = {mutationWithError: t_mutationWithError};
+  type operation = t;
+  let parse: Raw.t => t =
+    (value) => (
+      {
+        mutationWithError: {
+          let value = (value: Raw.t).mutationWithError;
+          (
+            {
+              errors: {
+                let value = (value: Raw.t_mutationWithError).errors;
+                switch (Js.toOption(value)) {
+                | Some(value) =>
+                  Some(
+                    value
+                    |> Js.Array.map((value) =>
+                         (
+                           {
+                             message: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).
+                                   message;
+                               value;
+                             },
+                             field: {
+                               let value =
+                                 (value: Raw.t_mutationWithError_errors).field;
+                               switch (Obj.magic(value: string)) {
+                               | "FIRST" => `FIRST
+                               | "SECOND" => `SECOND
+                               | "THIRD" => `THIRD
+                               | _ => raise(Not_found)
+                               };
+                             },
+                           }: t_mutationWithError_errors
+                         )
+                       ),
+                  )
+                | None => None
+                };
+              },
+            }: t_mutationWithError
+          );
+        },
+      }: t
+    );
+  let serialize: t => Raw.t =
+    (value) => (
+      {
+        let mutationWithError = {
+          let value = (value: t).mutationWithError;
+          (
+            {
+              let errors = {
+                let value = (value: t_mutationWithError).errors;
+                switch (value) {
+                | Some(value) =>
+                  Js.Nullable.return(
+                    value
+                    |> Js.Array.map((value) =>
+                         (
+                           {
+                             let field = {
+                               let value =
+                                 (value: t_mutationWithError_errors).field;
+                               switch (value) {
+                               | `FIRST => "FIRST"
+                               | `SECOND => "SECOND"
+                               | `THIRD => "THIRD"
+                               };
+                             }
+                             and message = {
+                               let value =
+                                 (value: t_mutationWithError_errors).message;
+                               value;
+                             };
+                             {message, field};
+                           }: Raw.t_mutationWithError_errors
+                         )
+                       ),
+                  )
+                | None => Js.Nullable.null
+                };
+              };
+              {errors: errors};
+            }: Raw.t_mutationWithError
+          );
+        };
+        {mutationWithError: mutationWithError};
+      }: Raw.t
+    );
+  let definition = (parse, query, serialize);
+};

--- a/tests_bucklescript/static_snapshots/records/operations/omitFutureValueUnion.re
+++ b/tests_bucklescript/static_snapshots/records/operations/omitFutureValueUnion.re
@@ -1,0 +1,356 @@
+[@ocaml.ppx.context
+  {
+    tool_name: "migrate_driver",
+    include_dirs: [],
+    load_path: [],
+    open_modules: [],
+    for_package: None,
+    debug: false,
+    use_threads: false,
+    use_vmthreads: false,
+    recursive_types: false,
+    principal: false,
+    transparent_modules: false,
+    unboxed_types: false,
+    unsafe_string: false,
+    cookies: [],
+  }
+];
+module Normal = {
+  module Raw = {
+    type t_dogOrHuman_Dog = {
+      __typename: string,
+      name: string,
+      barkVolume: float,
+    };
+    type t_dogOrHuman_Human = {
+      __typename: string,
+      name: string,
+    };
+    type t_dogOrHuman;
+    type t = {dogOrHuman: t_dogOrHuman};
+  };
+  let query = "query   {\ndogOrHuman  {\n__typename\n...on Dog   {\nname  \nbarkVolume  \n}\n\n...on Human   {\nname  \n}\n\n}\n\n}\n";
+  type t_dogOrHuman_Dog = {
+    name: string,
+    barkVolume: float,
+  };
+  type t_dogOrHuman_Human = {name: string};
+  type t_dogOrHuman = [
+    | `FutureAddedValue(Js.Json.t)
+    | `Dog(t_dogOrHuman_Dog)
+    | `Human(t_dogOrHuman_Human)
+  ];
+  type t = {dogOrHuman: t_dogOrHuman};
+  type operation = t;
+  let parse: Raw.t => t =
+    (value) => (
+      {
+        dogOrHuman: {
+          let value = (value: Raw.t).dogOrHuman;
+          let typename: string =
+            Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "__typename"));
+          (
+            switch (typename) {
+            | "Dog" =>
+              `Dog(
+                {
+                  let value: Raw.t_dogOrHuman_Dog = Obj.magic(value);
+                  (
+                    {
+                      name: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).name;
+                        value;
+                      },
+                      barkVolume: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).barkVolume;
+                        value;
+                      },
+                    }: t_dogOrHuman_Dog
+                  );
+                },
+              )
+            | "Human" =>
+              `Human(
+                {
+                  let value: Raw.t_dogOrHuman_Human = Obj.magic(value);
+                  (
+                    {
+                      name: {
+                        let value = (value: Raw.t_dogOrHuman_Human).name;
+                        value;
+                      },
+                    }: t_dogOrHuman_Human
+                  );
+                },
+              )
+            | _ => `FutureAddedValue(Obj.magic(value): Js.Json.t)
+            }: t_dogOrHuman
+          );
+        },
+      }: t
+    );
+  let serialize: t => Raw.t =
+    (value) => (
+      {
+        let dogOrHuman = {
+          let value = (value: t).dogOrHuman;
+          switch (value) {
+          | `Dog(value) => (
+              Obj.magic(
+                {
+                  let barkVolume = {
+                    let value = (value: t_dogOrHuman_Dog).barkVolume;
+                    value;
+                  }
+                  and name = {
+                    let value = (value: t_dogOrHuman_Dog).name;
+                    value;
+                  };
+                  {__typename: "Dog", name, barkVolume};
+                }: Raw.t_dogOrHuman_Dog,
+              ): Raw.t_dogOrHuman
+            )
+          | `Human(value) => (
+              Obj.magic(
+                {
+                  let name = {
+                    let value = (value: t_dogOrHuman_Human).name;
+                    value;
+                  };
+                  {__typename: "Human", name};
+                }: Raw.t_dogOrHuman_Human,
+              ): Raw.t_dogOrHuman
+            )
+          | `FutureAddedValue(value) => (Obj.magic(value): Raw.t_dogOrHuman)
+          };
+        };
+        {dogOrHuman: dogOrHuman};
+      }: Raw.t
+    );
+  let definition = (parse, query, serialize);
+};
+module ByConfig = {
+  module Raw = {
+    type t_dogOrHuman_Dog = {
+      __typename: string,
+      name: string,
+      barkVolume: float,
+    };
+    type t_dogOrHuman_Human = {
+      __typename: string,
+      name: string,
+    };
+    type t_dogOrHuman;
+    type t = {dogOrHuman: t_dogOrHuman};
+  };
+  let query = "query   {\ndogOrHuman  {\n__typename\n...on Dog   {\nname  \nbarkVolume  \n}\n\n...on Human   {\nname  \n}\n\n}\n\n}\n";
+  type t_dogOrHuman_Dog = {
+    name: string,
+    barkVolume: float,
+  };
+  type t_dogOrHuman_Human = {name: string};
+  type t_dogOrHuman = [
+    | `Dog(t_dogOrHuman_Dog)
+    | `Human(t_dogOrHuman_Human)
+  ];
+  type t = {dogOrHuman: t_dogOrHuman};
+  type operation = t;
+  let parse: Raw.t => t =
+    (value) => (
+      {
+        dogOrHuman: {
+          let value = (value: Raw.t).dogOrHuman;
+          let typename: string =
+            Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "__typename"));
+          (
+            switch (typename) {
+            | "Dog" =>
+              `Dog(
+                {
+                  let value: Raw.t_dogOrHuman_Dog = Obj.magic(value);
+                  (
+                    {
+                      name: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).name;
+                        value;
+                      },
+                      barkVolume: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).barkVolume;
+                        value;
+                      },
+                    }: t_dogOrHuman_Dog
+                  );
+                },
+              )
+            | "Human" =>
+              `Human(
+                {
+                  let value: Raw.t_dogOrHuman_Human = Obj.magic(value);
+                  (
+                    {
+                      name: {
+                        let value = (value: Raw.t_dogOrHuman_Human).name;
+                        value;
+                      },
+                    }: t_dogOrHuman_Human
+                  );
+                },
+              )
+            | _ => raise(Not_found)
+            }: t_dogOrHuman
+          );
+        },
+      }: t
+    );
+  let serialize: t => Raw.t =
+    (value) => (
+      {
+        let dogOrHuman = {
+          let value = (value: t).dogOrHuman;
+          switch (value) {
+          | `Dog(value) => (
+              Obj.magic(
+                {
+                  let barkVolume = {
+                    let value = (value: t_dogOrHuman_Dog).barkVolume;
+                    value;
+                  }
+                  and name = {
+                    let value = (value: t_dogOrHuman_Dog).name;
+                    value;
+                  };
+                  {__typename: "Dog", name, barkVolume};
+                }: Raw.t_dogOrHuman_Dog,
+              ): Raw.t_dogOrHuman
+            )
+          | `Human(value) => (
+              Obj.magic(
+                {
+                  let name = {
+                    let value = (value: t_dogOrHuman_Human).name;
+                    value;
+                  };
+                  {__typename: "Human", name};
+                }: Raw.t_dogOrHuman_Human,
+              ): Raw.t_dogOrHuman
+            )
+          };
+        };
+        {dogOrHuman: dogOrHuman};
+      }: Raw.t
+    );
+  let definition = (parse, query, serialize);
+};
+module ByDirective = {
+  module Raw = {
+    type t_dogOrHuman_Dog = {
+      __typename: string,
+      name: string,
+      barkVolume: float,
+    };
+    type t_dogOrHuman_Human = {
+      __typename: string,
+      name: string,
+    };
+    type t_dogOrHuman;
+    type t = {dogOrHuman: t_dogOrHuman};
+  };
+  let query = "query   {\ndogOrHuman @ppxOmitFutureValue {\n__typename\n...on Dog   {\nname  \nbarkVolume  \n}\n\n...on Human   {\nname  \n}\n\n}\n\n}\n";
+  type t_dogOrHuman_Dog = {
+    name: string,
+    barkVolume: float,
+  };
+  type t_dogOrHuman_Human = {name: string};
+  type t_dogOrHuman = [
+    | `Dog(t_dogOrHuman_Dog)
+    | `Human(t_dogOrHuman_Human)
+  ];
+  type t = {dogOrHuman: t_dogOrHuman};
+  type operation = t;
+  let parse: Raw.t => t =
+    (value) => (
+      {
+        dogOrHuman: {
+          let value = (value: Raw.t).dogOrHuman;
+          let typename: string =
+            Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "__typename"));
+          (
+            switch (typename) {
+            | "Dog" =>
+              `Dog(
+                {
+                  let value: Raw.t_dogOrHuman_Dog = Obj.magic(value);
+                  (
+                    {
+                      name: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).name;
+                        value;
+                      },
+                      barkVolume: {
+                        let value = (value: Raw.t_dogOrHuman_Dog).barkVolume;
+                        value;
+                      },
+                    }: t_dogOrHuman_Dog
+                  );
+                },
+              )
+            | "Human" =>
+              `Human(
+                {
+                  let value: Raw.t_dogOrHuman_Human = Obj.magic(value);
+                  (
+                    {
+                      name: {
+                        let value = (value: Raw.t_dogOrHuman_Human).name;
+                        value;
+                      },
+                    }: t_dogOrHuman_Human
+                  );
+                },
+              )
+            | _ => raise(Not_found)
+            }: t_dogOrHuman
+          );
+        },
+      }: t
+    );
+  let serialize: t => Raw.t =
+    (value) => (
+      {
+        let dogOrHuman = {
+          let value = (value: t).dogOrHuman;
+          switch (value) {
+          | `Dog(value) => (
+              Obj.magic(
+                {
+                  let barkVolume = {
+                    let value = (value: t_dogOrHuman_Dog).barkVolume;
+                    value;
+                  }
+                  and name = {
+                    let value = (value: t_dogOrHuman_Dog).name;
+                    value;
+                  };
+                  {__typename: "Dog", name, barkVolume};
+                }: Raw.t_dogOrHuman_Dog,
+              ): Raw.t_dogOrHuman
+            )
+          | `Human(value) => (
+              Obj.magic(
+                {
+                  let name = {
+                    let value = (value: t_dogOrHuman_Human).name;
+                    value;
+                  };
+                  {__typename: "Human", name};
+                }: Raw.t_dogOrHuman_Human,
+              ): Raw.t_dogOrHuman
+            )
+          };
+        };
+        {dogOrHuman: dogOrHuman};
+      }: Raw.t
+    );
+  let definition = (parse, query, serialize);
+};


### PR DESCRIPTION
Added the option of omitting the ``` `FutureAddedValue``` variant to enums / union variants. I also created some test cases for it and a readme entry (@jfrolich let me know if that doc format works, or if it's too much).