### PR TITLE
Require dune version >= 1.6 in opam file

### DIFF
--- a/graphql_ppx.opam
+++ b/graphql_ppx.opam
@@ -11,7 +11,7 @@ build: [
 depends: [
   "alcotest" {with-test}
   "cppo"
-  "dune"
+  "dune" {>= "1.6"}
   "ocaml" {>= "4.06.0"}
   "ocaml-migrate-parsetree" {>= "1.6.0"}
   "ppx_tools_versioned" {>= "5.2.3"}


### PR DESCRIPTION
The `dune-project` file requires at least dune 1.6, this PR adjusts the opam file accordingly.
See [https://github.com/ocaml/opam-repository/pull/16540](https://github.com/ocaml/opam-repository/pull/16540).